### PR TITLE
Rewrite semantic engine in PHP

### DIFF
--- a/src/SemanticEngine.php
+++ b/src/SemanticEngine.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * Core semantic engine for knowledge graph extraction.
+ */
+class SemanticEngine
+{
+    /** @var array<string, array<string, array<string, true>>> */
+    private array $graph = [];
+
+    /** @var array<string, array<string, true>> */
+    private array $synonyms = [];
+
+    /** @var array<string, true> */
+    private static array $entityStopwords = [
+        'a' => true,
+        'an' => true,
+        'the' => true,
+    ];
+
+    /**
+     * Normalise a token.
+     */
+    public function norm(string $token): string
+    {
+        $token = strtolower(trim($token));
+        $token = preg_replace('/[^0-9a-z-]+/i', '', $token);
+        return $token ?? '';
+    }
+
+    /**
+     * Normalise an entity while preserving multi-word layout.
+     */
+    public function normalizeEntity(?string $entity): string
+    {
+        if ($entity === null) {
+            return '';
+        }
+
+        $entity = strtolower(trim($entity));
+        if ($entity === '') {
+            return '';
+        }
+
+        $pieces = [];
+        $parts = preg_split('/(\s+|-+)/u', $entity, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        if ($parts === false) {
+            $parts = [];
+        }
+
+        $lastPiece = null;
+        foreach ($parts as $part) {
+            if (ctype_space($part)) {
+                if ($lastPiece !== ' ') {
+                    $pieces[] = ' ';
+                    $lastPiece = ' ';
+                }
+                continue;
+            }
+
+            if (preg_match('/^-+$/', $part)) {
+                if ($lastPiece !== '-') {
+                    $pieces[] = '-';
+                    $lastPiece = '-';
+                }
+                continue;
+            }
+
+            $token = $this->norm($part);
+            if ($token === '') {
+                continue;
+            }
+
+            if (empty($pieces) && isset(self::$entityStopwords[$token])) {
+                continue;
+            }
+
+            $pieces[] = $token;
+            $lastPiece = $token;
+        }
+
+        $normalized = trim(implode('', $pieces), " -");
+        return $normalized;
+    }
+
+    /**
+     * Add a triple to the knowledge graph.
+     */
+    public function addTriple(string $subject, string $relation, string $object): void
+    {
+        $subjectKey = $this->normalizeEntity($subject);
+        $objectKey = $this->normalizeEntity($object);
+        $relationKey = $this->norm($relation);
+
+        if ($subjectKey === '' || $objectKey === '' || $relationKey === '') {
+            return;
+        }
+
+        if (!isset($this->graph[$relationKey])) {
+            $this->graph[$relationKey] = [];
+        }
+        if (!isset($this->graph[$relationKey][$subjectKey])) {
+            $this->graph[$relationKey][$subjectKey] = [];
+        }
+
+        $this->graph[$relationKey][$subjectKey][$objectKey] = true;
+    }
+
+    /**
+     * Register synonyms between two entities.
+     */
+    public function addSynonym(string $left, string $right): void
+    {
+        $leftKey = $this->normalizeEntity($left);
+        $rightKey = $this->normalizeEntity($right);
+        if ($leftKey === '' || $rightKey === '' || $leftKey === $rightKey) {
+            return;
+        }
+
+        if (!isset($this->synonyms[$leftKey])) {
+            $this->synonyms[$leftKey] = [];
+        }
+        if (!isset($this->synonyms[$rightKey])) {
+            $this->synonyms[$rightKey] = [];
+        }
+
+        $this->synonyms[$leftKey][$rightKey] = true;
+        $this->synonyms[$rightKey][$leftKey] = true;
+    }
+
+    /**
+     * Determine if subject is-a object.
+     */
+    public function queryIsA(string $subject, string $object): bool
+    {
+        $subjectKey = $this->normalizeEntity($subject);
+        $objectKey = $this->normalizeEntity($object);
+        if ($subjectKey === '' || $objectKey === '') {
+            return false;
+        }
+
+        if (!isset($this->graph['isa'][$subjectKey])) {
+            return false;
+        }
+
+        return isset($this->graph['isa'][$subjectKey][$objectKey]);
+    }
+
+    /**
+     * Retrieve synonyms for an entity.
+     *
+     * @return array<int, string>
+     */
+    public function querySynonyms(string $entity): array
+    {
+        $key = $this->normalizeEntity($entity);
+        if ($key === '' || !isset($this->synonyms[$key])) {
+            return [];
+        }
+
+        return array_keys($this->synonyms[$key]);
+    }
+
+    /**
+     * Extract relation triples from text.
+     *
+     * @return array<int, array{0: string, 1: string, 2: string}>
+     */
+    public function extractRelations(string $text): array
+    {
+        $triples = [];
+        if (trim($text) === '') {
+            return $triples;
+        }
+
+        $sentences = preg_split('/[.!?]+/', $text);
+        if ($sentences === false) {
+            $sentences = [];
+        }
+
+        foreach ($sentences as $sentence) {
+            $sentence = trim($sentence);
+            if ($sentence === '') {
+                continue;
+            }
+
+            if (preg_match('/^(?P<subj>.+?)\s+is\s+(?:an?\s+)?(?P<obj>[\w\s\-]+)$/iu', $sentence, $matches)) {
+                $subjRaw = $matches['subj'];
+                $objRaw = $matches['obj'];
+                $this->addTriple($subjRaw, 'isa', $objRaw);
+                $subj = $this->normalizeEntity($subjRaw);
+                $obj = $this->normalizeEntity($objRaw);
+                if ($subj !== '' && $obj !== '') {
+                    $triples[] = [$subj, 'isa', $obj];
+                }
+                continue;
+            }
+
+            if (preg_match('/^(?P<left>.+?)\s+(aka|also known as|synonym of)\s+(?P<right>.+)$/iu', $sentence, $matches)) {
+                $leftRaw = $matches['left'];
+                $rightRaw = $matches['right'];
+                $this->addSynonym($leftRaw, $rightRaw);
+                $left = $this->normalizeEntity($leftRaw);
+                $right = $this->normalizeEntity($rightRaw);
+                if ($left !== '' && $right !== '') {
+                    $triples[] = [$left, 'synonym', $right];
+                }
+                continue;
+            }
+        }
+
+        return $triples;
+    }
+
+    /**
+     * Iterate over stored triples.
+     *
+     * @return array<int, array{0: string, 1: string, 2: string}>
+     */
+    public function iterTriples(?string $relation = null): array
+    {
+        $result = [];
+        if ($relation !== null) {
+            $relationKey = $this->norm($relation);
+            if ($relationKey === '' || !isset($this->graph[$relationKey])) {
+                return $result;
+            }
+
+            foreach ($this->graph[$relationKey] as $subject => $objects) {
+                foreach ($objects as $object => $_) {
+                    $result[] = [$subject, $relationKey, $object];
+                }
+            }
+            return $result;
+        }
+
+        foreach ($this->graph as $relationKey => $subjects) {
+            foreach ($subjects as $subject => $objects) {
+                foreach ($objects as $object => $_) {
+                    $result[] = [$subject, $relationKey, $object];
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Iterate over stored synonyms.
+     *
+     * @return array<int, array{0: string, 1: array<int, string>}>
+     */
+    public function iterSynonyms(): array
+    {
+        $result = [];
+        foreach ($this->synonyms as $key => $values) {
+            $result[] = [$key, array_keys($values)];
+        }
+        return $result;
+    }
+}

--- a/tests/test_semantic_engine.php
+++ b/tests/test_semantic_engine.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../src/SemanticEngine.php';
+
+ini_set('assert.exception', 1);
+
+function assertEquals($expected, $actual, string $message = ''): void {
+    if ($expected != $actual) {
+        $msg = $message !== '' ? $message . ' ' : '';
+        throw new AssertionError($msg . 'Expected ' . var_export($expected, true) . ' but got ' . var_export($actual, true));
+    }
+}
+
+function assertTrue(bool $value, string $message = ''): void {
+    if (!$value) {
+        throw new AssertionError($message !== '' ? $message : 'Expected true but got false');
+    }
+}
+
+function assertContains(array $needle, array $haystack, string $message = ''): void {
+    foreach ($haystack as $item) {
+        if ($item === $needle) {
+            return;
+        }
+    }
+    $msg = $message !== '' ? $message . ' ' : '';
+    throw new AssertionError($msg . 'Array ' . var_export($needle, true) . ' not found.');
+}
+
+$engine = new SemanticEngine();
+assertEquals('red fox', $engine->normalizeEntity('Red Fox'));
+assertEquals('blue-green', $engine->normalizeEntity('Blue-Green'));
+assertEquals('high-speed train', $engine->normalizeEntity('  High-Speed  Train  '));
+
+$engine = new SemanticEngine();
+$engine->addTriple('Red Fox', 'isa', 'Wild Animal');
+assertContains(['red fox', 'isa', 'wild animal'], $engine->iterTriples(), 'Triple not found');
+assertTrue($engine->queryIsA('red fox', 'wild animal'));
+
+$engine = new SemanticEngine();
+$engine->addSynonym('Red Fox', 'Vulpes Vulpes');
+assertEquals(['vulpes vulpes'], $engine->querySynonyms('red fox'));
+assertEquals(['red fox'], $engine->querySynonyms('Vulpes Vulpes'));
+
+$engine = new SemanticEngine();
+$text = 'The Red Fox is a Wild Animal. Red Fox also known as Vulpes Vulpes.';
+$triples = $engine->extractRelations($text);
+assertContains(['red fox', 'isa', 'wild animal'], $triples);
+assertContains(['red fox', 'synonym', 'vulpes vulpes'], $triples);
+assertTrue($engine->queryIsA('Red Fox', 'wild animal'));
+assertEquals(['vulpes vulpes'], $engine->querySynonyms('red fox'));
+
+$engine = new SemanticEngine();
+$text = 'High-speed train is a Transport System.';
+$triples = $engine->extractRelations($text);
+assertContains(['high-speed train', 'isa', 'transport system'], $triples);
+assertTrue($engine->queryIsA('High-Speed Train', 'transport system'));
+
+echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- replace the Python-based semantic engine with a PHP implementation that preserves multi-word entities via normalizeEntity
- port triple, synonym, and relation extraction logic to PHP while maintaining normalization semantics
- add PHP assertions-based regression tests covering normalization, triple ingestion, synonym queries, and extraction behaviour

## Testing
- php tests/test_semantic_engine.php

------
https://chatgpt.com/codex/tasks/task_e_68db90504b3c8327bb86157534338e51