### PR TITLE
Add decay-weighted co-occurrence builder

### DIFF
--- a/AiResearch/CoOccurrenceMatrixBuilder.php
+++ b/AiResearch/CoOccurrenceMatrixBuilder.php
@@ -1,0 +1,202 @@
+<?php
+namespace AiResearch;
+
+/**
+ * Build a word-context co-occurrence matrix from tokenised documents.
+ *
+ * The builder uses a symmetric sliding window and applies a configurable
+ * distance-based decay to context contributions. By default an inverse-distance
+ * policy (1 / distance) is used, but callers can switch to a linear decay or
+ * supply their own tuning via {@see setDecayPolicy()}.
+ */
+class CoOccurrenceMatrixBuilder
+{
+    /** @var int */
+    private int $windowRadius;
+
+    /**
+     * The decay policy controls how quickly the weight decreases as the
+     * context distance grows. Supported values: "inverse" (default) and
+     * "linear".
+     */
+    private string $decayPolicy = 'inverse';
+
+    /**
+     * For the inverse policy this represents the exponent (1 / distance^k).
+     * For the linear policy it represents the slope applied to (distance - 1).
+     */
+    private float $decayStrength = 1.0;
+
+    /** @var array<int|string, array<int|string, float>> */
+    private array $counts = [];
+
+    /** @var array<int|string, float> */
+    private array $sumRow = [];
+
+    /** @var array<int|string, float> */
+    private array $sumCol = [];
+
+    private float $sumAll = 0.0;
+
+    private bool $finalized = false;
+
+    public function __construct(int $windowRadius = 2, string $decayPolicy = 'inverse', ?float $decayStrength = null)
+    {
+        $this->windowRadius = max(1, $windowRadius);
+        $this->setDecayPolicy($decayPolicy, $decayStrength);
+    }
+
+    /**
+     * Configure the decay policy used to weight context positions.
+     *
+     * @param string     $policy   Either "inverse" (1 / distance^k) or
+     *                             "linear" (max(0, 1 - k * (distance - 1))).
+     * @param float|null $strength Optional tuning parameter. Defaults to 1 for
+     *                             inverse decay and 1 / windowRadius for linear
+     *                             decay.
+     */
+    public function setDecayPolicy(string $policy, ?float $strength = null): void
+    {
+        $policy = strtolower($policy);
+        if ($policy !== 'inverse' && $policy !== 'linear') {
+            throw new \InvalidArgumentException('Unknown decay policy: ' . $policy);
+        }
+
+        if ($strength === null) {
+            $strength = ($policy === 'linear') ? 1.0 / $this->windowRadius : 1.0;
+        }
+
+        if ($strength < 0.0) {
+            throw new \InvalidArgumentException('Decay strength must be >= 0.');
+        }
+
+        $this->decayPolicy = $policy;
+        $this->decayStrength = $strength;
+        $this->finalized = false;
+    }
+
+    /**
+     * @return array{policy: string, strength: float}
+     */
+    public function getDecayPolicy(): array
+    {
+        return ['policy' => $this->decayPolicy, 'strength' => $this->decayStrength];
+    }
+
+    /**
+     * Add a tokenised document to the matrix.
+     *
+     * Each target/context pair within the sliding window contributes to
+     * {@see $counts} with a weight determined by the configured decay policy.
+     *
+     * @param array<int, int|string> $tokens
+     */
+    public function addDocument(array $tokens): void
+    {
+        $count = count($tokens);
+        if ($count === 0) {
+            return;
+        }
+
+        for ($i = 0; $i < $count; $i++) {
+            $target = $tokens[$i];
+            if ($target === null || $target === '') {
+                continue;
+            }
+
+            for ($offset = 1; $offset <= $this->windowRadius; $offset++) {
+                $weight = $this->computeWeight($offset);
+                if ($weight === 0.0) {
+                    continue;
+                }
+
+                $left = $i - $offset;
+                if ($left >= 0) {
+                    $context = $tokens[$left];
+                    if ($context !== null && $context !== '') {
+                        $this->incrementCount($target, $context, $weight);
+                    }
+                }
+
+                $right = $i + $offset;
+                if ($right < $count) {
+                    $context = $tokens[$right];
+                    if ($context !== null && $context !== '') {
+                        $this->incrementCount($target, $context, $weight);
+                    }
+                }
+            }
+        }
+
+        $this->finalized = false;
+    }
+
+    private function computeWeight(int $distance): float
+    {
+        if ($distance <= 0) {
+            return 0.0;
+        }
+
+        if ($this->decayPolicy === 'inverse') {
+            if ($this->decayStrength === 0.0) {
+                return 1.0;
+            }
+            return 1.0 / pow((float) $distance, $this->decayStrength);
+        }
+
+        $weight = 1.0 - $this->decayStrength * ($distance - 1);
+        return ($weight > 0.0) ? $weight : 0.0;
+    }
+
+    /**
+     * @param int|string $target
+     * @param int|string $context
+     */
+    private function incrementCount($target, $context, float $weight): void
+    {
+        if (!isset($this->counts[$target])) {
+            $this->counts[$target] = [];
+        }
+        if (!isset($this->counts[$target][$context])) {
+            $this->counts[$target][$context] = 0.0;
+        }
+        $this->counts[$target][$context] += $weight;
+    }
+
+    /**
+     * Finalise accumulated statistics.
+     *
+     * @return array{counts: array<int|string, array<int|string, float>>, sumAll: float, sumRow: array<int|string, float>, sumCol: array<int|string, float>}
+     */
+    public function finalize(): array
+    {
+        if (!$this->finalized) {
+            $this->sumRow = [];
+            $this->sumCol = [];
+            $this->sumAll = 0.0;
+
+            foreach ($this->counts as $target => $contexts) {
+                $rowSum = 0.0;
+                foreach ($contexts as $context => $value) {
+                    $rowSum += $value;
+                    if (!isset($this->sumCol[$context])) {
+                        $this->sumCol[$context] = 0.0;
+                    }
+                    $this->sumCol[$context] += $value;
+                }
+
+                $this->sumRow[$target] = $rowSum;
+                $this->sumAll += $rowSum;
+            }
+
+            $this->finalized = true;
+        }
+
+        return [
+            'counts' => $this->counts,
+            'sumAll' => $this->sumAll,
+            'sumRow' => $this->sumRow,
+            'sumCol' => $this->sumCol,
+        ];
+    }
+}

--- a/tests/test_cooccurrence_matrix_builder.php
+++ b/tests/test_cooccurrence_matrix_builder.php
@@ -1,0 +1,59 @@
+<?php
+require_once __DIR__ . '/../AiResearch/CoOccurrenceMatrixBuilder.php';
+
+use AiResearch\CoOccurrenceMatrixBuilder;
+
+ini_set('assert.exception', '1');
+
+$builder = new CoOccurrenceMatrixBuilder(2, 'inverse');
+$builder->addDocument([1, 2, 3]);
+$result = $builder->finalize();
+
+$counts = $result['counts'];
+
+$expectedCounts = [
+    1 => [2 => 1.0, 3 => 0.5],
+    2 => [1 => 1.0, 3 => 1.0],
+    3 => [2 => 1.0, 1 => 0.5],
+];
+
+if ($counts != $expectedCounts) {
+    throw new AssertionError('Unexpected counts: ' . var_export($counts, true));
+}
+
+if ($result['sumAll'] !== 5.0) {
+    throw new AssertionError('sumAll expected 5.0 but got ' . var_export($result['sumAll'], true));
+}
+
+$expectedRow = [1 => 1.5, 2 => 2.0, 3 => 1.5];
+if ($result['sumRow'] !== $expectedRow) {
+    throw new AssertionError('Unexpected row sums: ' . var_export($result['sumRow'], true));
+}
+
+$expectedCol = [2 => 2.0, 3 => 1.5, 1 => 1.5];
+if ($result['sumCol'] !== $expectedCol) {
+    throw new AssertionError('Unexpected column sums: ' . var_export($result['sumCol'], true));
+}
+
+$builder = new CoOccurrenceMatrixBuilder(3);
+$builder->setDecayPolicy('linear', 0.25);
+$builder->addDocument(['a', 'b', 'c', 'd']);
+$final = $builder->finalize();
+
+$policy = $builder->getDecayPolicy();
+if ($policy['policy'] !== 'linear' || abs($policy['strength'] - 0.25) > 1e-9) {
+    throw new AssertionError('Unexpected decay policy: ' . var_export($policy, true));
+}
+
+$weightDistance1 = $final['counts']['b']['a'];
+$weightDistance2 = $final['counts']['a']['c'];
+
+if (abs($weightDistance1 - 1.0) > 1e-9) {
+    throw new AssertionError('Linear decay distance1 mismatch: ' . $weightDistance1);
+}
+
+if (abs($weightDistance2 - 0.75) > 1e-9) {
+    throw new AssertionError('Linear decay distance2 mismatch: ' . $weightDistance2);
+}
+
+echo "CoOccurrenceMatrixBuilder tests passed\n";


### PR DESCRIPTION
## Summary
- add a configurable co-occurrence matrix builder that applies distance-based decay weights
- store co-occurrence counts as floats and compute aggregate sums during finalization
- add regression coverage for weighted counts and decay configuration behaviour

## Testing
- php tests/test_semantic_engine.php
- php tests/test_infer.php
- php tests/test_cooccurrence_matrix_builder.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc44ed6988327ba408969ad144143