### PR TITLE
Expand semantic engine demo with complex scenario

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,6 +10,12 @@ $biographies = [
     <<<BIO
     Ricktorious Limited is a technology company. Ricktorious Limited aka Ricktorious Ltd.
     BIO,
+    <<<BIO
+    Bob Hernandez is an AI Research Engineer. Bob Hernandez also known as Robert J. Hernandez.
+    BIO,
+    <<<BIO
+    Carla Rossi is a Principal Investigator. Carla leads the Horizon Lab. Horizon Lab aka Horizon Research Laboratory.
+    BIO,
 ];
 
 $extractedTriples = [];
@@ -22,17 +28,43 @@ foreach ($biographies as $bio) {
 
 $engine->addTriple('Alice Smith', 'works_at', 'Ricktorious Limited');
 $engine->addTriple('Alice Smith', 'lives_at', 'Birmingham, United Kingdom');
+$engine->addTriple('Alice Smith', 'collaborates_with', 'Bob Hernandez');
+$engine->addTriple('Bob Hernandez', 'works_at', 'Horizon Lab');
+$engine->addTriple('Carla Rossi', 'leads', 'Horizon Lab');
+$engine->addTriple('Horizon Lab', 'focuses_on', 'Responsible AI Research');
+$engine->addTriple('Horizon Lab', 'located_in', 'London, United Kingdom');
+
 $engine->addSynonym('Birmingham', 'City of Birmingham');
+$engine->addSynonym('Responsible AI Research', 'RAI Research');
+$engine->addSynonym('London, United Kingdom', 'City of London');
+$engine->addSynonym('Horizon Lab', 'Horizon Research Laboratory');
+
+$engine->addTriple('Alice Smith', 'isa', 'Senior Data Scientist');
+$engine->addTriple('Bob Hernandez', 'isa', 'AI Research Engineer');
+$engine->addTriple('Carla Rossi', 'isa', 'Principal Investigator');
 
 $insights = [
     'alice_is_data_scientist' => $engine->queryIsA('Alice Smith', 'Senior Data Scientist'),
     'alice_synonyms' => $engine->querySynonyms('Alice Smith'),
     'company_synonyms' => $engine->querySynonyms('Ricktorious Limited'),
     'city_synonyms' => $engine->querySynonyms('Birmingham'),
+    'horizon_lab_synonyms' => $engine->querySynonyms('Horizon Lab'),
+    'rai_synonyms' => $engine->querySynonyms('Responsible AI Research'),
 ];
 
 $graphTriples = $engine->iterTriples();
 $synonymPairs = $engine->iterSynonyms();
+$isaTriples = $engine->iterTriples('isa');
+
+function groupTriplesByRelation(array $triples): array {
+    $grouped = [];
+    foreach ($triples as [$subject, $relation, $object]) {
+        $grouped[$relation][] = [$subject, $object];
+    }
+
+    ksort($grouped);
+    return $grouped;
+}
 
 function renderHeader(string $title): void {
     echo str_repeat('=', 80) . PHP_EOL;
@@ -50,6 +82,16 @@ function renderTable(array $rows): void {
     }
 }
 
+function renderGroupedTriples(array $grouped): void {
+    foreach ($grouped as $relation => $pairs) {
+        echo strtoupper($relation) . PHP_EOL;
+        foreach ($pairs as [$subject, $object]) {
+            echo sprintf("  • %s -> %s", $subject, $object) . PHP_EOL;
+        }
+        echo PHP_EOL;
+    }
+}
+
 renderHeader('Extracted triples from biographies');
 renderTable($extractedTriples);
 
@@ -62,6 +104,14 @@ foreach ($insights as $label => $value) {
 echo PHP_EOL;
 renderHeader('All triples currently stored');
 renderTable($graphTriples);
+
+echo PHP_EOL;
+renderHeader('Triples grouped by relation');
+renderGroupedTriples(groupTriplesByRelation($graphTriples));
+
+echo PHP_EOL;
+renderHeader('All known isa relationships');
+renderTable($isaTriples);
 
 echo PHP_EOL;
 renderHeader('Synonym clusters');


### PR DESCRIPTION
## Summary
- add two additional biographies and manually curated facts to build a richer semantic graph demo
- introduce grouped triple rendering and focused isa extraction outputs for easier inspection of relations
- expand synonym coverage to highlight clustering behaviour in the example output

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68dc08dd5b5c8327bb80fd75c898d2a7