### PR TITLE
Expand semantic extraction patterns

### DIFF
--- a/src/SemanticEngine.php
+++ b/src/SemanticEngine.php
@@ -126,6 +126,9 @@ class SemanticEngine
 
         $this->synonyms[$leftKey][$rightKey] = true;
         $this->synonyms[$rightKey][$leftKey] = true;
+
+        $this->addTriple($left, 'synonym', $right);
+        $this->addTriple($right, 'synonym', $left);
     }
 
     /**
@@ -178,6 +181,33 @@ class SemanticEngine
             $sentences = [];
         }
 
+        $relationPatterns = [
+            [
+                'regex' => '/^(?P<subject>.+?)\s+works\s+(?:at|for)\s+(?P<object>.+)$/iu',
+                'relation' => 'works_at',
+            ],
+            [
+                'regex' => '/^(?P<subject>.+?)\s+lives\s+(?:in|at)\s+(?P<object>.+)$/iu',
+                'relation' => 'lives_in',
+            ],
+            [
+                'regex' => '/^(?P<subject>.+?)\s+(?:leads|heads)\s+(?P<object>.+)$/iu',
+                'relation' => 'leads',
+            ],
+            [
+                'regex' => '/^(?P<subject>.+?)\s+focuses\s+on\s+(?P<object>.+)$/iu',
+                'relation' => 'focuses_on',
+            ],
+            [
+                'regex' => '/^(?P<subject>.+?)\s+located\s+(?:in|at)\s+(?P<object>.+)$/iu',
+                'relation' => 'located_in',
+            ],
+            [
+                'regex' => '/^(?P<subject>.+?)\s+collaborates\s+with\s+(?P<object>.+)$/iu',
+                'relation' => 'collaborates_with',
+            ],
+        ];
+
         foreach ($sentences as $sentence) {
             $sentence = trim($sentence);
             if ($sentence === '') {
@@ -206,6 +236,22 @@ class SemanticEngine
                     $triples[] = [$left, 'synonym', $right];
                 }
                 continue;
+            }
+
+            foreach ($relationPatterns as $pattern) {
+                if (!preg_match($pattern['regex'], $sentence, $matches)) {
+                    continue;
+                }
+
+                $subjectRaw = $matches['subject'];
+                $objectRaw = $matches['object'];
+                $this->addTriple($subjectRaw, $pattern['relation'], $objectRaw);
+                $subject = $this->normalizeEntity($subjectRaw);
+                $object = $this->normalizeEntity($objectRaw);
+                if ($subject !== '' && $object !== '') {
+                    $triples[] = [$subject, $this->norm($pattern['relation']), $object];
+                }
+                continue 2;
             }
         }
 

--- a/tests/test_semantic_engine.php
+++ b/tests/test_semantic_engine.php
@@ -40,6 +40,9 @@ $engine = new SemanticEngine();
 $engine->addSynonym('Red Fox', 'Vulpes Vulpes');
 assertEquals(['vulpes vulpes'], $engine->querySynonyms('red fox'));
 assertEquals(['red fox'], $engine->querySynonyms('Vulpes Vulpes'));
+$synonymTriples = $engine->iterTriples('synonym');
+assertContains(['red fox', 'synonym', 'vulpes vulpes'], $synonymTriples);
+assertContains(['vulpes vulpes', 'synonym', 'red fox'], $synonymTriples);
 
 $engine = new SemanticEngine();
 $text = 'The Red Fox is a Wild Animal. Red Fox also known as Vulpes Vulpes.';
@@ -48,11 +51,31 @@ assertContains(['red fox', 'isa', 'wild animal'], $triples);
 assertContains(['red fox', 'synonym', 'vulpes vulpes'], $triples);
 assertTrue($engine->queryIsA('Red Fox', 'wild animal'));
 assertEquals(['vulpes vulpes'], $engine->querySynonyms('red fox'));
+$synonymTriples = $engine->iterTriples('synonym');
+assertContains(['red fox', 'synonym', 'vulpes vulpes'], $synonymTriples);
+assertContains(['vulpes vulpes', 'synonym', 'red fox'], $synonymTriples);
 
 $engine = new SemanticEngine();
 $text = 'High-speed train is a Transport System.';
 $triples = $engine->extractRelations($text);
 assertContains(['high-speed train', 'isa', 'transport system'], $triples);
 assertTrue($engine->queryIsA('High-Speed Train', 'transport system'));
+
+$engine = new SemanticEngine();
+$text = 'Alice Smith works at Ricktorious Limited. Alice Smith lives in Birmingham. Carla Rossi leads the Horizon Lab. Horizon Lab focuses on Responsible AI Research. Horizon Lab located in London, United Kingdom. Alice Smith collaborates with Bob Hernandez.';
+$triples = $engine->extractRelations($text);
+assertContains(['alice smith', 'worksat', 'ricktorious limited'], $triples);
+assertContains(['alice smith', 'livesin', 'birmingham'], $triples);
+assertContains(['carla rossi', 'leads', 'horizon lab'], $triples);
+assertContains(['horizon lab', 'focuseson', 'responsible ai research'], $triples);
+assertContains(['horizon lab', 'locatedin', 'london united kingdom'], $triples);
+assertContains(['alice smith', 'collaborateswith', 'bob hernandez'], $triples);
+
+$worksAtTriples = $engine->iterTriples('works_at');
+assertContains(['alice smith', 'worksat', 'ricktorious limited'], $worksAtTriples);
+$livesInTriples = $engine->iterTriples('lives_in');
+assertContains(['alice smith', 'livesin', 'birmingham'], $livesInTriples);
+$collaboratesTriples = $engine->iterTriples('collaborates_with');
+assertContains(['alice smith', 'collaborateswith', 'bob hernandez'], $collaboratesTriples);
 
 echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- add synonym triples to the knowledge graph when registering aliases
- extend relation extraction with patterns for employment, residence, leadership, focus, location, and collaboration
- broaden semantic engine tests to cover synonym triples and newly supported relations

## Testing
- php tests/test_semantic_engine.php
- php tests/test_cooccurrence_matrix_builder.php
- php tests/test_infer.php

------
https://chatgpt.com/codex/tasks/task_e_68dc09d60efc83279c75e76e22e2d89e