### PR TITLE
Add PPMI computation helper and synonym inference test

### DIFF
--- a/AiResearch/CoOccurrenceMatrixBuilder.php
+++ b/AiResearch/CoOccurrenceMatrixBuilder.php
@@ -199,4 +199,57 @@ class CoOccurrenceMatrixBuilder
             'sumCol' => $this->sumCol,
         ];
     }
+
+    /**
+     * Compute a sparse Positive Pointwise Mutual Information matrix.
+     *
+     * The matrix is keyed by target token id with inner arrays containing the
+     * positive PMI scores for each context id. Negative PMI values are clipped
+     * to zero and therefore omitted from the resulting sparse structure.
+     *
+     * @return array<int|string, array<int|string, float>>
+     */
+    public function computePpmi(): array
+    {
+        $this->finalize();
+
+        if ($this->sumAll <= 0.0) {
+            return [];
+        }
+
+        $ppmi = [];
+
+        foreach ($this->counts as $target => $contexts) {
+            $rowTotal = $this->sumRow[$target] ?? 0.0;
+            if ($rowTotal <= 0.0) {
+                continue;
+            }
+
+            foreach ($contexts as $context => $count) {
+                if ($count <= 0.0) {
+                    continue;
+                }
+
+                $colTotal = $this->sumCol[$context] ?? 0.0;
+                if ($colTotal <= 0.0) {
+                    continue;
+                }
+
+                $denominator = $rowTotal * $colTotal;
+                if ($denominator <= 0.0) {
+                    continue;
+                }
+
+                $pmi = log(($count * $this->sumAll) / $denominator);
+                if ($pmi > 0.0) {
+                    if (!isset($ppmi[$target])) {
+                        $ppmi[$target] = [];
+                    }
+                    $ppmi[$target][$context] = $pmi;
+                }
+            }
+        }
+
+        return $ppmi;
+    }
 }

--- a/tests/test_cooccurrence_matrix_builder.php
+++ b/tests/test_cooccurrence_matrix_builder.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../AiResearch/CoOccurrenceMatrixBuilder.php';
+require_once __DIR__ . '/../AiResearch/infer.php';
 
 use AiResearch\CoOccurrenceMatrixBuilder;
 
@@ -54,6 +55,46 @@ if (abs($weightDistance1 - 1.0) > 1e-9) {
 
 if (abs($weightDistance2 - 0.75) > 1e-9) {
     throw new AssertionError('Linear decay distance2 mismatch: ' . $weightDistance2);
+}
+
+$builder = new CoOccurrenceMatrixBuilder(1);
+$corpus = [
+    [1, 3, 2, 3],
+    [2, 3, 1, 3],
+    [1, 3, 2, 3],
+];
+
+foreach ($corpus as $document) {
+    $builder->addDocument($document);
+}
+
+$ppmi = $builder->computePpmi();
+
+$idToWord = [
+    1 => 'alpha',
+    2 => 'beta',
+    3 => 'gamma',
+];
+
+$pairs = \AiResearch\infer($ppmi, $idToWord, 0.0);
+
+if (empty($pairs)) {
+    throw new AssertionError('Expected synonym pairs but none were inferred.');
+}
+
+$found = false;
+foreach ($pairs as [$left, $right, $score]) {
+    if ($left === 'alpha' && $right === 'beta') {
+        if ($score <= 0.0) {
+            throw new AssertionError('Expected positive similarity score for alpha/beta pair.');
+        }
+        $found = true;
+        break;
+    }
+}
+
+if (!$found) {
+    throw new AssertionError('Expected alpha/beta synonym pair not found: ' . var_export($pairs, true));
 }
 
 echo "CoOccurrenceMatrixBuilder tests passed\n";


### PR DESCRIPTION
## Summary
- add a computePpmi helper that transforms co-occurrence counts into a sparse PPMI matrix
- clip negative PMI scores and expose the sparse matrix for downstream inference
- extend the co-occurrence builder tests to cover PPMI computation and synonym inference

## Testing
- php tests/test_cooccurrence_matrix_builder.php

------
https://chatgpt.com/codex/tasks/task_e_68dc2dbf1f0c8327b833a3d7133fb4bf