### PR TITLE
Add CLI input parsing and export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# AIresearch Semantic Extraction CLI
+
+This repository exposes the `SemanticEngine` through a small command line
+utility (`index.php`). The command ingests free-form biographies or research
+summaries and extracts lightweight knowledge graph triples and synonym
+relationships.
+
+## Usage
+
+```
+php index.php [options] [file ...]
+```
+
+When no files are supplied, the command reads from `STDIN`. You can also mix
+files with `-` to explicitly read from `STDIN` alongside other inputs.
+
+> **Note:** Entities and relation labels are normalised to lower-case tokens
+> without punctuation. For example, the `lives_in` relation becomes `livesin` in
+> the exported data.
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show inline help and exit. |
+| `-f, --format FORMAT` | Output format: `text` (default), `json`, or `csv`. |
+| `-e, --export TYPE` | Select data to export: `triples` or `synonyms`. Repeat the option to export both. |
+| `-o, --output PATH` | Write the formatted output to the provided path instead of `STDOUT`. |
+
+## Examples
+
+### Reading from a file
+
+```
+cat > sample.txt <<'EOF'
+Alice Smith is a Senior Data Scientist. Alice Smith aka Ally Smith. Alice Smith lives in Birmingham.
+EOF
+
+php index.php sample.txt
+```
+
+Output (default `text` format):
+
+```
+Triples:
+- alice smith | isa | senior data scientist
+- alice smith | synonym | ally smith
+- ally smith | synonym | alice smith
+- alice smith | livesin | birmingham
+Synonyms:
+- alice smith => ally smith
+- ally smith => alice smith
+```
+
+### Reading from STDIN
+
+```
+cat <<'EOF' | php index.php -f json
+Ricktorious Limited is a technology company. Ricktorious Limited aka Ricktorious Ltd.
+EOF
+```
+
+JSON output:
+
+```json
+{
+    "triples": [
+        {
+            "subject": "ricktorious limited",
+            "relation": "isa",
+            "object": "technology company"
+        },
+        {
+            "subject": "ricktorious limited",
+            "relation": "synonym",
+            "object": "ricktorious ltd"
+        },
+        {
+            "subject": "ricktorious ltd",
+            "relation": "synonym",
+            "object": "ricktorious limited"
+        }
+    ],
+    "synonyms": [
+        {
+            "entity": "ricktorious limited",
+            "synonyms": [
+                "ricktorious ltd"
+            ]
+        },
+        {
+            "entity": "ricktorious ltd",
+            "synonyms": [
+                "ricktorious limited"
+            ]
+        }
+    ]
+}
+```
+
+### CSV export
+
+CSV export is limited to a single data type per invocation. The example below
+writes triples to `triples.csv`.
+
+```
+php index.php -f csv -e triples sample.txt -o triples.csv
+cat triples.csv
+```
+
+Contents:
+
+```
+subject,relation,object
+"alice smith",isa,"senior data scientist"
+"alice smith",synonym,"ally smith"
+"ally smith",synonym,"alice smith"
+"alice smith",livesin,birmingham
+```
+
+To export synonyms instead:
+
+```
+php index.php -f csv -e synonyms sample.txt
+```
+
+## Error handling
+
+The command validates option values and reports descriptive errors when inputs
+cannot be read or when no text is provided. Use `php index.php --help` to view a
+summary of all available options.

--- a/index.php
+++ b/index.php
@@ -1,120 +1,325 @@
 <?php
 require __DIR__ . '/src/SemanticEngine.php';
 
-$engine = new SemanticEngine();
+function printUsage(): void
+{
+    $usage = <<<'USAGE'
+Usage: php index.php [options] [file ...]
 
-$biographies = [
-    <<<BIO
-    Alice Smith is a Senior Data Scientist. Alice Smith aka Ally Smith. Alice lives in Birmingham.
-    BIO,
-    <<<BIO
-    Ricktorious Limited is a technology company. Ricktorious Limited aka Ricktorious Ltd.
-    BIO,
-    <<<BIO
-    Bob Hernandez is an AI Research Engineer. Bob Hernandez also known as Robert J. Hernandez.
-    BIO,
-    <<<BIO
-    Carla Rossi is a Principal Investigator. Carla leads the Horizon Lab. Horizon Lab aka Horizon Research Laboratory.
-    BIO,
-];
+Options:
+  -h, --help              Show this help message.
+  -f, --format FORMAT     Output format: text (default), json, csv.
+  -e, --export TYPE       Data to export: triples, synonyms. May be repeated.
+  -o, --output PATH       Write output to the specified file instead of STDOUT.
 
-$extractedTriples = [];
-foreach ($biographies as $bio) {
-    $triples = $engine->extractRelations($bio);
-    if ($triples !== []) {
-        array_push($extractedTriples, ...$triples);
-    }
+If no files are provided, the command reads from STDIN. Use "-" as a file
+argument to explicitly read from STDIN alongside other files.
+USAGE;
+
+    fwrite(STDOUT, $usage . PHP_EOL);
 }
 
-$engine->addTriple('Alice Smith', 'works_at', 'Ricktorious Limited');
-$engine->addTriple('Alice Smith', 'lives_at', 'Birmingham, United Kingdom');
-$engine->addTriple('Alice Smith', 'collaborates_with', 'Bob Hernandez');
-$engine->addTriple('Bob Hernandez', 'works_at', 'Horizon Lab');
-$engine->addTriple('Carla Rossi', 'leads', 'Horizon Lab');
-$engine->addTriple('Horizon Lab', 'focuses_on', 'Responsible AI Research');
-$engine->addTriple('Horizon Lab', 'located_in', 'London, United Kingdom');
+function fatalError(string $message): void
+{
+    fwrite(STDERR, 'Error: ' . $message . PHP_EOL);
+    exit(1);
+}
 
-$engine->addSynonym('Birmingham', 'City of Birmingham');
-$engine->addSynonym('Responsible AI Research', 'RAI Research');
-$engine->addSynonym('London, United Kingdom', 'City of London');
-$engine->addSynonym('Horizon Lab', 'Horizon Research Laboratory');
+/**
+ * @param array<int, string> $argv
+ * @return array{options: array{format: string, exports: array<int, string>, output: ?string, help: bool}, files: array<int, string>}
+ */
+function parseArguments(array $argv): array
+{
+    $args = $argv;
+    array_shift($args);
 
-$engine->addTriple('Alice Smith', 'isa', 'Senior Data Scientist');
-$engine->addTriple('Bob Hernandez', 'isa', 'AI Research Engineer');
-$engine->addTriple('Carla Rossi', 'isa', 'Principal Investigator');
+    $options = [
+        'format' => 'text',
+        'exports' => [],
+        'output' => null,
+        'help' => false,
+    ];
+    $files = [];
 
-$insights = [
-    'alice_is_data_scientist' => $engine->queryIsA('Alice Smith', 'Senior Data Scientist'),
-    'alice_synonyms' => $engine->querySynonyms('Alice Smith'),
-    'company_synonyms' => $engine->querySynonyms('Ricktorious Limited'),
-    'city_synonyms' => $engine->querySynonyms('Birmingham'),
-    'horizon_lab_synonyms' => $engine->querySynonyms('Horizon Lab'),
-    'rai_synonyms' => $engine->querySynonyms('Responsible AI Research'),
-];
+    while ($args !== []) {
+        $arg = array_shift($args);
+        if ($arg === null) {
+            break;
+        }
 
-$graphTriples = $engine->iterTriples();
-$synonymPairs = $engine->iterSynonyms();
-$isaTriples = $engine->iterTriples('isa');
+        switch ($arg) {
+            case '-h':
+            case '--help':
+                $options['help'] = true;
+                continue 2;
+            case '-f':
+            case '--format':
+                $value = array_shift($args);
+                if ($value === null) {
+                    fatalError('Missing value for --format option.');
+                }
+                $options['format'] = $value;
+                continue 2;
+            case '-e':
+            case '--export':
+                $value = array_shift($args);
+                if ($value === null) {
+                    fatalError('Missing value for --export option.');
+                }
+                $options['exports'][] = $value;
+                continue 2;
+            case '-o':
+            case '--output':
+                $value = array_shift($args);
+                if ($value === null) {
+                    fatalError('Missing value for --output option.');
+                }
+                $options['output'] = $value;
+                continue 2;
+        }
 
-function groupTriplesByRelation(array $triples): array {
-    $grouped = [];
+        if (strpos($arg, '--format=') === 0) {
+            $options['format'] = substr($arg, 9);
+            continue;
+        }
+
+        if (strpos($arg, '--export=') === 0) {
+            $options['exports'][] = substr($arg, 9);
+            continue;
+        }
+
+        if (strpos($arg, '--output=') === 0) {
+            $options['output'] = substr($arg, 9);
+            continue;
+        }
+
+        $files[] = $arg;
+    }
+
+    return ['options' => $options, 'files' => $files];
+}
+
+/**
+ * @param array<int, string> $files
+ * @return array<int, string>
+ */
+function readInputTexts(array $files): array
+{
+    $texts = [];
+    $stdinConsumed = false;
+
+    if ($files === []) {
+        $stdin = stream_get_contents(STDIN);
+        if ($stdin === false) {
+            fatalError('Unable to read from STDIN.');
+        }
+        if (trim($stdin) !== '') {
+            $texts[] = $stdin;
+        }
+        return $texts;
+    }
+
+    foreach ($files as $file) {
+        if ($file === '-') {
+            if ($stdinConsumed) {
+                continue;
+            }
+            $stdin = stream_get_contents(STDIN);
+            if ($stdin === false) {
+                fatalError('Unable to read from STDIN.');
+            }
+            if (trim($stdin) !== '') {
+                $texts[] = $stdin;
+            }
+            $stdinConsumed = true;
+            continue;
+        }
+
+        if (!is_file($file) || !is_readable($file)) {
+            fatalError(sprintf('Cannot read file "%s".', $file));
+        }
+
+        $contents = file_get_contents($file);
+        if ($contents === false) {
+            fatalError(sprintf('Failed to read file "%s".', $file));
+        }
+
+        if (trim($contents) !== '') {
+            $texts[] = $contents;
+        }
+    }
+
+    return $texts;
+}
+
+/**
+ * @param array<int, array{0: string, 1: string, 2: string}> $triples
+ */
+function formatTriplesText(array $triples): string
+{
+    if ($triples === []) {
+        return "No triples extracted." . PHP_EOL;
+    }
+
+    $lines = ["Triples:" . PHP_EOL];
     foreach ($triples as [$subject, $relation, $object]) {
-        $grouped[$relation][] = [$subject, $object];
+        $lines[] = sprintf("- %s | %s | %s", $subject, $relation, $object) . PHP_EOL;
     }
 
-    ksort($grouped);
-    return $grouped;
+    return implode('', $lines);
 }
 
-function renderHeader(string $title): void {
-    echo str_repeat('=', 80) . PHP_EOL;
-    echo $title . PHP_EOL;
-    echo str_repeat('=', 80) . PHP_EOL;
+/**
+ * @param array<int, array{0: string, 1: array<int, string>}> $synonyms
+ */
+function formatSynonymsText(array $synonyms): string
+{
+    if ($synonyms === []) {
+        return "No synonyms stored." . PHP_EOL;
+    }
+
+    $lines = ["Synonyms:" . PHP_EOL];
+    foreach ($synonyms as [$entity, $values]) {
+        $lines[] = sprintf("- %s => %s", $entity, implode(', ', $values)) . PHP_EOL;
+    }
+
+    return implode('', $lines);
 }
 
-function renderTable(array $rows): void {
+/**
+ * @param array<int, array<int, string>> $rows
+ * @param array<int, string> $header
+ */
+function buildCsv(array $rows, array $header): string
+{
+    $handle = fopen('php://temp', 'r+');
+    if ($handle === false) {
+        fatalError('Failed to initialise CSV buffer.');
+    }
+
+    $delimiter = ',';
+    $enclosure = "\"";
+    $escape = "\\";
+    fputcsv($handle, $header, $delimiter, $enclosure, $escape);
     foreach ($rows as $row) {
-        if (is_array($row)) {
-            echo '- ' . implode(' | ', array_map('strval', $row)) . PHP_EOL;
+        fputcsv($handle, $row, $delimiter, $enclosure, $escape);
+    }
+
+    rewind($handle);
+    $csv = stream_get_contents($handle);
+    if ($csv === false) {
+        fclose($handle);
+        fatalError('Failed to read CSV buffer.');
+    }
+
+    fclose($handle);
+    return $csv;
+}
+
+$parsed = parseArguments($argv);
+$options = $parsed['options'];
+$files = $parsed['files'];
+
+if ($options['help']) {
+    printUsage();
+    exit(0);
+}
+
+$format = strtolower($options['format']);
+$validFormats = ['text', 'json', 'csv'];
+if (!in_array($format, $validFormats, true)) {
+    fatalError(sprintf('Invalid format "%s". Expected one of: %s.', $options['format'], implode(', ', $validFormats)));
+}
+
+$exports = $options['exports'] === [] ? ['triples', 'synonyms'] : $options['exports'];
+$exports = array_values(array_unique(array_map('strtolower', $exports)));
+$validExports = ['triples', 'synonyms'];
+foreach ($exports as $export) {
+    if (!in_array($export, $validExports, true)) {
+        fatalError(sprintf('Invalid export "%s". Expected one of: %s.', $export, implode(', ', $validExports)));
+    }
+}
+
+if ($format === 'csv' && count($exports) !== 1) {
+    fatalError('CSV format supports exporting a single data type. Provide exactly one --export option.');
+}
+
+$texts = readInputTexts($files);
+if ($texts === []) {
+    fatalError('No input text provided. Specify files or pipe text via STDIN.');
+}
+
+$engine = new SemanticEngine();
+foreach ($texts as $text) {
+    $engine->extractRelations($text);
+}
+
+$outputPayload = [];
+$triples = [];
+$synonyms = [];
+
+if (in_array('triples', $exports, true)) {
+    $triples = $engine->iterTriples();
+}
+if (in_array('synonyms', $exports, true)) {
+    $synonyms = $engine->iterSynonyms();
+}
+
+switch ($format) {
+    case 'json':
+        if (in_array('triples', $exports, true)) {
+            $outputPayload['triples'] = array_map(
+                static fn(array $triple): array => [
+                    'subject' => $triple[0],
+                    'relation' => $triple[1],
+                    'object' => $triple[2],
+                ],
+                $triples
+            );
+        }
+        if (in_array('synonyms', $exports, true)) {
+            $outputPayload['synonyms'] = array_map(
+                static fn(array $pair): array => [
+                    'entity' => $pair[0],
+                    'synonyms' => $pair[1],
+                ],
+                $synonyms
+            );
+        }
+        $encoded = json_encode($outputPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            fatalError('Failed to encode JSON output.');
+        }
+        $outputData = $encoded . PHP_EOL;
+        break;
+    case 'csv':
+        if ($exports[0] === 'triples') {
+            $rows = array_map(static fn(array $triple): array => [$triple[0], $triple[1], $triple[2]], $triples);
+            $outputData = buildCsv($rows, ['subject', 'relation', 'object']);
         } else {
-            echo '- ' . (string) $row . PHP_EOL;
+            $rows = array_map(static fn(array $pair): array => [$pair[0], implode(';', $pair[1])], $synonyms);
+            $outputData = buildCsv($rows, ['entity', 'synonyms']);
         }
-    }
-}
-
-function renderGroupedTriples(array $grouped): void {
-    foreach ($grouped as $relation => $pairs) {
-        echo strtoupper($relation) . PHP_EOL;
-        foreach ($pairs as [$subject, $object]) {
-            echo sprintf("  • %s -> %s", $subject, $object) . PHP_EOL;
+        break;
+    default:
+        $sections = [];
+        if (in_array('triples', $exports, true)) {
+            $sections[] = formatTriplesText($triples);
         }
-        echo PHP_EOL;
+        if (in_array('synonyms', $exports, true)) {
+            $sections[] = formatSynonymsText($synonyms);
+        }
+        $outputData = implode(PHP_EOL, array_map('rtrim', $sections)) . PHP_EOL;
+        break;
+}
+
+if ($options['output'] !== null) {
+    $bytes = @file_put_contents($options['output'], $outputData);
+    if ($bytes === false) {
+        fatalError(sprintf('Failed to write output to "%s".', $options['output']));
     }
+    exit(0);
 }
 
-renderHeader('Extracted triples from biographies');
-renderTable($extractedTriples);
-
-echo PHP_EOL;
-renderHeader('Direct insights from the knowledge graph');
-foreach ($insights as $label => $value) {
-    echo sprintf('- %s: %s', $label, is_bool($value) ? ($value ? 'true' : 'false') : json_encode($value, JSON_THROW_ON_ERROR)) . PHP_EOL;
-}
-
-echo PHP_EOL;
-renderHeader('All triples currently stored');
-renderTable($graphTriples);
-
-echo PHP_EOL;
-renderHeader('Triples grouped by relation');
-renderGroupedTriples(groupTriplesByRelation($graphTriples));
-
-echo PHP_EOL;
-renderHeader('All known isa relationships');
-renderTable($isaTriples);
-
-echo PHP_EOL;
-renderHeader('Synonym clusters');
-foreach ($synonymPairs as [$entity, $synonyms]) {
-    echo '- ' . $entity . ' => ' . implode(', ', $synonyms) . PHP_EOL;
-}
+echo $outputData;


### PR DESCRIPTION
## Summary
- replace the demo script in `index.php` with a CLI that reads files or STDIN and validates arguments
- add selectable exports for triples and synonyms with text, JSON, and CSV output plus optional file writes
- document the new command usage and sample outputs in a repository README

## Testing
- php -l index.php
- php tests/test_semantic_engine.php

------
https://chatgpt.com/codex/tasks/task_e_68dc2f9605748327adf32905bc12b09f