### PR TITLE
Add snapshot serialization helpers to SemanticEngine

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,6 +11,8 @@ Options:
   -f, --format FORMAT     Output format: text (default), json, csv.
   -e, --export TYPE       Data to export: triples, synonyms. May be repeated.
   -o, --output PATH       Write output to the specified file instead of STDOUT.
+  -s, --snapshot PATH     Load an existing engine snapshot from PATH and
+                          overwrite it with the updated state after processing.
 
 If no files are provided, the command reads from STDIN. Use "-" as a file
 argument to explicitly read from STDIN alongside other files.
@@ -27,7 +29,7 @@ function fatalError(string $message): void
 
 /**
  * @param array<int, string> $argv
- * @return array{options: array{format: string, exports: array<int, string>, output: ?string, help: bool}, files: array<int, string>}
+ * @return array{options: array{format: string, exports: array<int, string>, output: ?string, help: bool, snapshot: ?string}, files: array<int, string>}
  */
 function parseArguments(array $argv): array
 {
@@ -39,6 +41,7 @@ function parseArguments(array $argv): array
         'exports' => [],
         'output' => null,
         'help' => false,
+        'snapshot' => null,
     ];
     $files = [];
 
@@ -77,6 +80,14 @@ function parseArguments(array $argv): array
                 }
                 $options['output'] = $value;
                 continue 2;
+            case '-s':
+            case '--snapshot':
+                $value = array_shift($args);
+                if ($value === null) {
+                    fatalError('Missing value for --snapshot option.');
+                }
+                $options['snapshot'] = $value;
+                continue 2;
         }
 
         if (strpos($arg, '--format=') === 0) {
@@ -91,6 +102,11 @@ function parseArguments(array $argv): array
 
         if (strpos($arg, '--output=') === 0) {
             $options['output'] = substr($arg, 9);
+            continue;
+        }
+
+        if (strpos($arg, '--snapshot=') === 0) {
+            $options['snapshot'] = substr($arg, 11);
             continue;
         }
 
@@ -250,7 +266,33 @@ if ($texts === []) {
     fatalError('No input text provided. Specify files or pipe text via STDIN.');
 }
 
-$engine = new SemanticEngine();
+$snapshotPath = $options['snapshot'];
+if ($snapshotPath !== null) {
+    $snapshotPath = trim($snapshotPath);
+    if ($snapshotPath === '') {
+        $snapshotPath = null;
+    }
+}
+
+if ($snapshotPath !== null && is_file($snapshotPath)) {
+    $contents = file_get_contents($snapshotPath);
+    if ($contents === false) {
+        fatalError(sprintf('Failed to read snapshot file "%s".', $snapshotPath));
+    }
+
+    $decoded = json_decode($contents, true);
+    if (!is_array($decoded)) {
+        fatalError(sprintf('Snapshot file "%s" does not contain valid JSON.', $snapshotPath));
+    }
+
+    $engine = SemanticEngine::fromArray($decoded);
+} else {
+    if ($snapshotPath !== null && file_exists($snapshotPath) && !is_file($snapshotPath)) {
+        fatalError(sprintf('Snapshot path "%s" is not a regular file.', $snapshotPath));
+    }
+    $engine = new SemanticEngine();
+}
+
 foreach ($texts as $text) {
     $engine->extractRelations($text);
 }
@@ -319,7 +361,28 @@ if ($options['output'] !== null) {
     if ($bytes === false) {
         fatalError(sprintf('Failed to write output to "%s".', $options['output']));
     }
+    if ($snapshotPath !== null) {
+        $snapshotData = json_encode($engine->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($snapshotData === false) {
+            fatalError('Failed to encode snapshot data as JSON.');
+        }
+        $bytes = @file_put_contents($snapshotPath, $snapshotData . PHP_EOL);
+        if ($bytes === false) {
+            fatalError(sprintf('Failed to write snapshot to "%s".', $snapshotPath));
+        }
+    }
     exit(0);
 }
 
 echo $outputData;
+
+if ($snapshotPath !== null) {
+    $snapshotData = json_encode($engine->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($snapshotData === false) {
+        fatalError('Failed to encode snapshot data as JSON.');
+    }
+    $bytes = @file_put_contents($snapshotPath, $snapshotData . PHP_EOL);
+    if ($bytes === false) {
+        fatalError(sprintf('Failed to write snapshot to "%s".', $snapshotPath));
+    }
+}

--- a/src/SemanticEngine.php
+++ b/src/SemanticEngine.php
@@ -304,4 +304,78 @@ class SemanticEngine
         }
         return $result;
     }
+
+    /**
+     * Export the engine state.
+     *
+     * @return array{graph: array<string, array<string, array<string, true>>>, synonyms: array<string, array<string, true>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'graph' => $this->graph,
+            'synonyms' => $this->synonyms,
+        ];
+    }
+
+    /**
+     * Restore an engine instance from exported state.
+     *
+     * @param array{graph?: mixed, synonyms?: mixed} $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $engine = new self();
+
+        if (isset($payload['graph']) && is_array($payload['graph'])) {
+            foreach ($payload['graph'] as $relation => $subjects) {
+                if (!is_string($relation) || $relation === '' || !is_array($subjects)) {
+                    continue;
+                }
+
+                foreach ($subjects as $subject => $objects) {
+                    if (!is_string($subject) || $subject === '' || !is_array($objects)) {
+                        continue;
+                    }
+
+                    foreach ($objects as $object => $flag) {
+                        if (!is_string($object) || $object === '' || $flag !== true) {
+                            continue;
+                        }
+
+                        if (!isset($engine->graph[$relation])) {
+                            $engine->graph[$relation] = [];
+                        }
+                        if (!isset($engine->graph[$relation][$subject])) {
+                            $engine->graph[$relation][$subject] = [];
+                        }
+
+                        $engine->graph[$relation][$subject][$object] = true;
+                    }
+                }
+            }
+        }
+
+        if (isset($payload['synonyms']) && is_array($payload['synonyms'])) {
+            foreach ($payload['synonyms'] as $entity => $synonyms) {
+                if (!is_string($entity) || $entity === '' || !is_array($synonyms)) {
+                    continue;
+                }
+
+                foreach ($synonyms as $synonym => $flag) {
+                    if (!is_string($synonym) || $synonym === '' || $flag !== true) {
+                        continue;
+                    }
+
+                    if (!isset($engine->synonyms[$entity])) {
+                        $engine->synonyms[$entity] = [];
+                    }
+
+                    $engine->synonyms[$entity][$synonym] = true;
+                }
+            }
+        }
+
+        return $engine;
+    }
 }

--- a/tests/test_semantic_engine_snapshot.php
+++ b/tests/test_semantic_engine_snapshot.php
@@ -1,0 +1,52 @@
+<?php
+require_once __DIR__ . '/../src/SemanticEngine.php';
+
+ini_set('assert.exception', 1);
+
+function assertEquals($expected, $actual, string $message = ''): void {
+    if ($expected != $actual) {
+        $msg = $message !== '' ? $message . ' ' : '';
+        throw new AssertionError($msg . 'Expected ' . var_export($expected, true) . ' but got ' . var_export($actual, true));
+    }
+}
+
+function assertTrue(bool $value, string $message = ''): void {
+    if (!$value) {
+        throw new AssertionError($message !== '' ? $message : 'Expected true but got false');
+    }
+}
+
+function assertContains(array $needle, array $haystack, string $message = ''): void {
+    foreach ($haystack as $item) {
+        if ($item === $needle) {
+            return;
+        }
+    }
+    $msg = $message !== '' ? $message . ' ' : '';
+    throw new AssertionError($msg . 'Array ' . var_export($needle, true) . ' not found.');
+}
+
+$engine = new SemanticEngine();
+$engine->addTriple('Red Fox', 'isa', 'Wild Animal');
+$engine->addTriple('Red Fox', 'located_in', 'Europe');
+$engine->addSynonym('Red Fox', 'Vulpes Vulpes');
+
+$exported = $engine->toArray();
+assertTrue(isset($exported['graph']), 'Graph missing from export payload');
+assertTrue(isset($exported['synonyms']), 'Synonyms missing from export payload');
+
+$restored = SemanticEngine::fromArray($exported);
+
+assertTrue($restored->queryIsA('red fox', 'wild animal'), 'Restored engine lost isa relation');
+assertContains(['red fox', 'locatedin', 'europe'], $restored->iterTriples('located_in'));
+assertEquals(['vulpes vulpes'], $restored->querySynonyms('red fox'));
+
+$allTriples = $restored->iterTriples();
+assertContains(['red fox', 'isa', 'wild animal'], $allTriples);
+assertContains(['red fox', 'synonym', 'vulpes vulpes'], $allTriples);
+
+$roundTrip = SemanticEngine::fromArray($restored->toArray());
+assertTrue($roundTrip->queryIsA('red fox', 'wild animal'));
+assertEquals(['vulpes vulpes'], $roundTrip->querySynonyms('red fox'));
+
+echo "Snapshot tests passed\n";


### PR DESCRIPTION
## Summary
- add export/import helpers on SemanticEngine for persisting graph and synonym state
- enhance CLI to support loading and saving snapshots while processing text inputs
- introduce regression tests ensuring graphs survive serialization and restoration

## Testing
- php tests/test_semantic_engine_snapshot.php
- php tests/test_semantic_engine.php

------
https://chatgpt.com/codex/tasks/task_e_68dc320da5f48327805ff7de16089285