### PR TITLE
Prevent works_at extraction from complement clause subjects

### DIFF
--- a/src/SemanticEngine.php
+++ b/src/SemanticEngine.php
@@ -244,6 +244,44 @@ class SemanticEngine
                 }
 
                 $subjectRaw = $matches['subject'];
+                if ($pattern['relation'] === 'works_at') {
+                    $normalizedSubject = $this->normalizeEntity($subjectRaw);
+                    $tokens = preg_split('/\s+/u', $normalizedSubject);
+                    if ($tokens === false) {
+                        $tokens = [];
+                    }
+
+                    $complementisers = [
+                        'what' => true,
+                        'that' => true,
+                        'whether' => true,
+                        'because' => true,
+                    ];
+
+                    $hasComplementiser = false;
+                    foreach ($tokens as $token) {
+                        if ($token === '') {
+                            continue;
+                        }
+                        if (isset($complementisers[$token])) {
+                            $hasComplementiser = true;
+                            break;
+                        }
+                    }
+
+                    $tokenLimit = 6;
+                    $tokenCount = 0;
+                    foreach ($tokens as $token) {
+                        if ($token !== '') {
+                            $tokenCount++;
+                        }
+                    }
+
+                    if ($normalizedSubject === '' || $hasComplementiser || $tokenCount > $tokenLimit) {
+                        continue 2;
+                    }
+                }
+
                 $objectRaw = $matches['object'];
                 $this->addTriple($subjectRaw, $pattern['relation'], $objectRaw);
                 $subject = $this->normalizeEntity($subjectRaw);

--- a/tests/test_semantic_engine.php
+++ b/tests/test_semantic_engine.php
@@ -62,6 +62,15 @@ assertContains(['high-speed train', 'isa', 'transport system'], $triples);
 assertTrue($engine->queryIsA('High-Speed Train', 'transport system'));
 
 $engine = new SemanticEngine();
+$text = 'Officials told the BBC they kept the arrangement because that\'s what works for their interests.';
+$triples = $engine->extractRelations($text);
+foreach ($triples as $triple) {
+    if ($triple[1] === 'worksat') {
+        throw new AssertionError('Unexpected worksat triple for complement clause subjects');
+    }
+}
+
+$engine = new SemanticEngine();
 $text = 'Alice Smith works at Ricktorious Limited. Alice Smith lives in Birmingham. Carla Rossi leads the Horizon Lab. Horizon Lab focuses on Responsible AI Research. Horizon Lab located in London, United Kingdom. Alice Smith collaborates with Bob Hernandez.';
 $triples = $engine->extractRelations($text);
 assertContains(['alice smith', 'worksat', 'ricktorious limited'], $triples);


### PR DESCRIPTION
## Summary
- tighten works_at relation extraction by filtering complementisers and long subject phrases
- add a regression test to ensure the BBC "that's what works for their interests" sentence does not emit a worksat triple

## Testing
- php tests/test_semantic_engine.php

------
https://chatgpt.com/codex/tasks/task_e_68dcce172980832794493edc7e8b7379