### PR TITLE
Add Ricktorious ecommerce scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,14 @@ php index.php -f csv -e synonyms sample.txt
 The command validates option values and reports descriptive errors when inputs
 cannot be read or when no text is provided. Use `php index.php --help` to view a
 summary of all available options.
+
+## Ricktorious Limited Ecommerce Initiative
+
+The repository now includes a prototype ecommerce kernel for Ricktorious
+Limited. Explore `docs/ricktorious-ecommerce.md` for the architectural vision
+and run the interactive storefront via `php -S 0.0.0.0:8000 -t web` and visiting
+`/ricktorious.php`. The prototype ships with:
+
+- Extension-driven block registry (`src/Ricktorious/Ecommerce`).
+- Behaviour tracking and a stub personalisation engine.
+- An ad-hoc JSON API at `/api/insights` exposing per-user engagement metrics.

--- a/docs/ricktorious-ecommerce.md
+++ b/docs/ricktorious-ecommerce.md
@@ -1,0 +1,62 @@
+# Ricktorious Limited Ecommerce Platform Vision
+
+This document captures the target architecture for transforming the existing
+semantic tooling codebase into an extensible, AI-driven ecommerce experience
+for **Ricktorious Limited**. The focus is on creating a block-based, content
+managed storefront that can evolve through lightweight extensions.
+
+## Guiding Principles
+
+1. **Extension-first** – Every capability should be delivered through modular
+   extensions. Core services provide lifecycle hooks and shared utilities while
+   feature bundles live in self-contained packages.
+2. **Block-based experience** – Storefront pages are composed of content blocks
+   that can be re-ordered, re-configured, and swapped without editing PHP view
+   templates. Blocks expose schema metadata so low-code editors can surface
+   friendly controls.
+3. **Rich content management** – Merchandisers require structured page
+   definitions, draft/publish workflows, and the ability to seed dynamic product
+   collections. The platform should remain storage-agnostic to allow swapping a
+   database or headless CMS later in the project.
+4. **AI-first personalisation** – Behavioural data collection feeds a
+   personalisation engine that suggests content blocks and merchandising rules
+   to improve engagement.
+5. **Ad-hoc APIs** – A lightweight router exposes JSON endpoints for extensions
+   to serve configuration UIs, analytics dashboards, or integration hooks.
+
+## High-level Components
+
+- **Application kernel** – Coordinates bootstrapping, extension registration,
+  content rendering, and API dispatch.
+- **Block registry** – Stores block definitions, their default settings, and
+  render callbacks. Blocks are namespaced by extension and must describe their
+  configurable schema.
+- **Content manager** – Maintains structured page definitions that reference
+  block instances. It abstracts the persistence layer so data can be stored in
+  files, a relational database, or a remote CMS.
+- **Extension manager** – Handles discovery, bootstrapping, and lifecycle hooks
+  for extension packages. Extensions can register blocks, seed content, and
+  attach API routes.
+- **Ad-hoc API router** – Minimal HTTP router that supports extension-provided
+  endpoints without committing to a heavy framework.
+- **User behaviour tracker** – Normalises, stores, and exposes behavioural
+  events (product views, cart additions, etc.).
+- **AI personalisation engine** – Consumes behavioural events to compute
+  real-time insights and recommend high-performing block combinations.
+
+## Initial Deliverable
+
+The initial code deliverable introduces the core scaffolding:
+
+- New PHP namespaces under `Ricktorious\Ecommerce` implementing the
+  architecture above.
+- A `CoreContentExtension` that ships default blocks (hero, product grid) and a
+  seed homepage layout.
+- An example front controller at `web/ricktorious.php` that renders the
+  block-based homepage and exposes a sample AI insight endpoint at
+  `/api/insights`.
+- Behaviour tracker and AI engine stubs capable of ingesting events and
+  computing simple popularity recommendations.
+
+Subsequent iterations will layer in persistence, administrative interfaces, and
+comprehensive analytics dashboards.

--- a/src/Ricktorious/Ecommerce/AI/PersonalizationEngine.php
+++ b/src/Ricktorious/Ecommerce/AI/PersonalizationEngine.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\AI;
+
+use Ricktorious\Ecommerce\Analytics\UserBehaviorTracker;
+
+/**
+ * Simplified AI engine that surfaces popular blocks per user.
+ */
+final class PersonalizationEngine
+{
+    public function __construct(private UserBehaviorTracker $tracker)
+    {
+    }
+
+    /**
+     * Produce aggregate insights for the provided user.
+     *
+     * @return array<string, mixed>
+     */
+    public function insights(string $userId): array
+    {
+        $events = $this->tracker->eventsForUser($userId);
+        $counts = [];
+        foreach ($events as $event) {
+            $block = (string) ($event['payload']['block'] ?? 'unknown');
+            $counts[$block] = ($counts[$block] ?? 0) + 1;
+        }
+
+        arsort($counts);
+
+        return [
+            'user' => $userId,
+            'total_events' => count($events),
+            'block_popularity' => $counts,
+        ];
+    }
+
+    /**
+     * Recommend blocks to surface based on observed engagement.
+     *
+     * @param array<int, string> $availableBlocks
+     *
+     * @return array<int, string>
+     */
+    public function recommendBlocks(string $userId, array $availableBlocks): array
+    {
+        $insights = $this->insights($userId);
+        $popularity = (array) ($insights['block_popularity'] ?? []);
+        if ($popularity === []) {
+            return $availableBlocks;
+        }
+
+        $scored = [];
+        foreach ($availableBlocks as $blockName) {
+            $scored[$blockName] = $popularity[$blockName] ?? 0;
+        }
+
+        arsort($scored);
+
+        return array_keys($scored);
+    }
+}

--- a/src/Ricktorious/Ecommerce/Analytics/UserBehaviorTracker.php
+++ b/src/Ricktorious/Ecommerce/Analytics/UserBehaviorTracker.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Analytics;
+
+/**
+ * Captures lightweight behavioural events for personalisation.
+ */
+final class UserBehaviorTracker
+{
+    /**
+     * @var array<int, array{user: string, event: string, payload: array<string, mixed>, timestamp: int}>
+     */
+    private array $events = [];
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function recordEvent(string $userId, string $event, array $payload = []): void
+    {
+        $this->events[] = [
+            'user' => $userId,
+            'event' => $event,
+            'payload' => $payload,
+            'timestamp' => time(),
+        ];
+    }
+
+    /**
+     * @return array<int, array{user: string, event: string, payload: array<string, mixed>, timestamp: int}>
+     */
+    public function allEvents(): array
+    {
+        return $this->events;
+    }
+
+    /**
+     * @return array<int, array{user: string, event: string, payload: array<string, mixed>, timestamp: int}>
+     */
+    public function eventsForUser(string $userId): array
+    {
+        return array_values(array_filter(
+            $this->events,
+            static fn(array $event): bool => $event['user'] === $userId
+        ));
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/AdhocApiRouter.php
+++ b/src/Ricktorious/Ecommerce/Core/AdhocApiRouter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+/**
+ * Minimal router for JSON-centric API endpoints.
+ */
+final class AdhocApiRouter
+{
+    /** @var array<string, array<string, callable>> */
+    private array $routes = [];
+
+    public function addRoute(string $method, string $path, callable $handler): void
+    {
+        $method = strtoupper($method);
+        $this->routes[$method][$path] = $handler;
+    }
+
+    /**
+     * Dispatch the route and return a standard response payload.
+     *
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $payload
+     *
+     * @return array{status: int, headers: array<string, string>, body: mixed}
+     */
+    public function dispatch(string $method, string $path, array $query = [], array $payload = []): array
+    {
+        $method = strtoupper($method);
+        $handler = $this->routes[$method][$path] ?? null;
+        if ($handler === null) {
+            return [
+                'status' => 404,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => ['error' => 'Not Found'],
+            ];
+        }
+
+        $response = $handler($query, $payload);
+        if (!is_array($response) || !isset($response['body'])) {
+            $response = [
+                'status' => 200,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $response,
+            ];
+        }
+
+        $status = (int) ($response['status'] ?? 200);
+        $headers = (array) ($response['headers'] ?? ['Content-Type' => 'application/json']);
+        $body = $response['body'];
+
+        return [
+            'status' => $status,
+            'headers' => $headers,
+            'body' => $body,
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, callable>>
+     */
+    public function routes(): array
+    {
+        return $this->routes;
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/Application.php
+++ b/src/Ricktorious/Ecommerce/Core/Application.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+use Ricktorious\Ecommerce\AI\PersonalizationEngine;
+use Ricktorious\Ecommerce\Analytics\UserBehaviorTracker;
+
+final class Application
+{
+    private bool $booted = false;
+
+    public function __construct(
+        private BlockRegistry $blockRegistry,
+        private ContentManager $contentManager,
+        private ExtensionManager $extensionManager,
+        private AdhocApiRouter $apiRouter,
+        private UserBehaviorTracker $behaviorTracker,
+        private PersonalizationEngine $personalizationEngine
+    ) {
+    }
+
+    public function boot(): void
+    {
+        if ($this->booted) {
+            return;
+        }
+
+        $this->extensionManager->boot($this->blockRegistry, $this->contentManager, $this->apiRouter);
+        $this->booted = true;
+    }
+
+    /**
+     * Render a page based on its block layout definition.
+     *
+     * @return array{title: string, html: string, metadata: array<string, mixed>}
+     */
+    public function renderPage(string $identifier, array $context = []): array
+    {
+        $this->boot();
+        $page = $this->contentManager->getPage($identifier);
+        if ($page === null) {
+            return [
+                'title' => 'Page not found',
+                'html' => '<p class="empty">Page not found.</p>',
+                'metadata' => [],
+            ];
+        }
+
+        $blocks = (array) ($page['blocks'] ?? []);
+        $fragments = [];
+        foreach ($blocks as $blockDefinition) {
+            $type = (string) ($blockDefinition['type'] ?? '');
+            if ($type === '' || !$this->blockRegistry->has($type)) {
+                continue;
+            }
+
+            $settings = (array) ($blockDefinition['settings'] ?? []);
+            $block = $this->blockRegistry->get($type);
+            $fragments[] = $block->render($settings, $context);
+        }
+
+        $metadata = (array) ($page['metadata'] ?? []);
+        $title = (string) ($metadata['title'] ?? 'Ricktorious Storefront');
+
+        return [
+            'title' => $title,
+            'html' => implode(PHP_EOL, $fragments),
+            'metadata' => $metadata,
+        ];
+    }
+
+    /**
+     * Dispatch an API request to the ad-hoc router.
+     *
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $payload
+     *
+     * @return array{status: int, headers: array<string, string>, body: mixed}
+     */
+    public function handleApiRequest(string $method, string $path, array $query = [], array $payload = []): array
+    {
+        $this->boot();
+
+        return $this->apiRouter->dispatch($method, $path, $query, $payload);
+    }
+
+    public function behaviorTracker(): UserBehaviorTracker
+    {
+        return $this->behaviorTracker;
+    }
+
+    public function personalizationEngine(): PersonalizationEngine
+    {
+        return $this->personalizationEngine;
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/BlockRegistry.php
+++ b/src/Ricktorious/Ecommerce/Core/BlockRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+use InvalidArgumentException;
+
+/**
+ * Registry of available blocks.
+ */
+final class BlockRegistry
+{
+    /** @var array<string, BlockType> */
+    private array $blocks = [];
+
+    public function register(BlockType $block): void
+    {
+        $name = $block->getName();
+        if ($name === '') {
+            throw new InvalidArgumentException('Block names must be non-empty strings.');
+        }
+
+        $this->blocks[$name] = $block;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->blocks[$name]);
+    }
+
+    public function get(string $name): BlockType
+    {
+        if (!$this->has($name)) {
+            throw new InvalidArgumentException(sprintf('Unknown block "%s".', $name));
+        }
+
+        return $this->blocks[$name];
+    }
+
+    /**
+     * @return array<string, BlockType>
+     */
+    public function all(): array
+    {
+        return $this->blocks;
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/BlockType.php
+++ b/src/Ricktorious/Ecommerce/Core/BlockType.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+/**
+ * Represents a block that can be rendered on the storefront.
+ */
+final class BlockType
+{
+    /** @var callable */
+    private $renderer;
+
+    /** @param callable $renderer */
+    public function __construct(
+        private string $name,
+        private string $label,
+        callable $renderer,
+        private array $schema = [],
+        private array $defaultSettings = []
+    ) {
+        $this->renderer = $renderer;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Return the schema describing configurable options.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array
+    {
+        return $this->schema;
+    }
+
+    /**
+     * Render the block with the provided settings and context.
+     *
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $context
+     */
+    public function render(array $settings = [], array $context = []): string
+    {
+        $payload = array_replace_recursive($this->defaultSettings, $settings);
+
+        return (string) ($this->renderer)($payload, $context);
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/ContentManager.php
+++ b/src/Ricktorious/Ecommerce/Core/ContentManager.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+/**
+ * Lightweight in-memory content manager for page layouts.
+ */
+final class ContentManager
+{
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $pages = [];
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    public function definePage(string $identifier, array $definition): void
+    {
+        $this->pages[$identifier] = $definition;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPage(string $identifier): ?array
+    {
+        return $this->pages[$identifier] ?? null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function allPages(): array
+    {
+        return $this->pages;
+    }
+}

--- a/src/Ricktorious/Ecommerce/Core/ExtensionInterface.php
+++ b/src/Ricktorious/Ecommerce/Core/ExtensionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+use Ricktorious\Ecommerce\Core\BlockRegistry;
+use Ricktorious\Ecommerce\Core\ContentManager;
+use Ricktorious\Ecommerce\Core\AdhocApiRouter;
+
+/**
+ * Contract for Ricktorious ecommerce extensions.
+ */
+interface ExtensionInterface
+{
+    public function getIdentifier(): string;
+
+    public function registerBlocks(BlockRegistry $registry): void;
+
+    public function boot(ContentManager $contentManager): void;
+
+    public function registerApis(AdhocApiRouter $router): void;
+}

--- a/src/Ricktorious/Ecommerce/Core/ExtensionManager.php
+++ b/src/Ricktorious/Ecommerce/Core/ExtensionManager.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Core;
+
+use InvalidArgumentException;
+
+final class ExtensionManager
+{
+    /** @var array<string, ExtensionInterface> */
+    private array $extensions = [];
+
+    public function addExtension(ExtensionInterface $extension): void
+    {
+        $identifier = $extension->getIdentifier();
+        if ($identifier === '') {
+            throw new InvalidArgumentException('Extension identifiers must not be empty.');
+        }
+        if (isset($this->extensions[$identifier])) {
+            throw new InvalidArgumentException(sprintf('Extension "%s" is already registered.', $identifier));
+        }
+
+        $this->extensions[$identifier] = $extension;
+    }
+
+    public function boot(BlockRegistry $registry, ContentManager $contentManager, AdhocApiRouter $router): void
+    {
+        foreach ($this->extensions as $extension) {
+            $extension->registerBlocks($registry);
+            $extension->boot($contentManager);
+            $extension->registerApis($router);
+        }
+    }
+
+    /**
+     * @return array<string, ExtensionInterface>
+     */
+    public function all(): array
+    {
+        return $this->extensions;
+    }
+}

--- a/src/Ricktorious/Ecommerce/Extensions/CoreContentExtension.php
+++ b/src/Ricktorious/Ecommerce/Extensions/CoreContentExtension.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ricktorious\Ecommerce\Extensions;
+
+use Ricktorious\Ecommerce\Core\AdhocApiRouter;
+use Ricktorious\Ecommerce\Core\BlockRegistry;
+use Ricktorious\Ecommerce\Core\BlockType;
+use Ricktorious\Ecommerce\Core\ContentManager;
+use Ricktorious\Ecommerce\Core\ExtensionInterface;
+use Ricktorious\Ecommerce\AI\PersonalizationEngine;
+use Ricktorious\Ecommerce\Analytics\UserBehaviorTracker;
+
+final class CoreContentExtension implements ExtensionInterface
+{
+    public function __construct(
+        private UserBehaviorTracker $tracker,
+        private PersonalizationEngine $personalization
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'ricktorious.core_content';
+    }
+
+    public function registerBlocks(BlockRegistry $registry): void
+    {
+        $registry->register(new BlockType(
+            'core.hero',
+            'Hero banner',
+            static function (array $settings, array $context): string {
+                $heading = htmlspecialchars((string) ($settings['heading'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $subtitle = htmlspecialchars((string) ($settings['subtitle'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $ctaLabel = htmlspecialchars((string) ($settings['cta_label'] ?? 'Shop now'), ENT_QUOTES, 'UTF-8');
+                $ctaUrl = htmlspecialchars((string) ($settings['cta_url'] ?? '#'), ENT_QUOTES, 'UTF-8');
+
+                return <<<HTML
+<section class="block hero">
+    <div class="hero__content">
+        <h1>{$heading}</h1>
+        <p>{$subtitle}</p>
+        <a class="button" href="{$ctaUrl}">{$ctaLabel}</a>
+    </div>
+</section>
+HTML;
+            },
+            schema: [
+                'heading' => ['type' => 'string', 'label' => 'Heading'],
+                'subtitle' => ['type' => 'text', 'label' => 'Subtitle'],
+                'cta_label' => ['type' => 'string', 'label' => 'CTA label'],
+                'cta_url' => ['type' => 'string', 'label' => 'CTA URL'],
+            ],
+            defaultSettings: [
+                'heading' => 'Discover Ricktorious Limited',
+                'subtitle' => 'A block-based ecommerce experience for modern brands.',
+                'cta_label' => 'Explore products',
+                'cta_url' => '#products',
+            ]
+        ));
+
+        $registry->register(new BlockType(
+            'core.product_grid',
+            'Product grid',
+            function (array $settings, array $context): string {
+                $products = $settings['products'] ?? $context['products'] ?? [];
+                if (!is_array($products)) {
+                    $products = [];
+                }
+
+                $items = [];
+                foreach ($products as $product) {
+                    $title = htmlspecialchars((string) ($product['title'] ?? 'Unnamed product'), ENT_QUOTES, 'UTF-8');
+                    $price = htmlspecialchars((string) ($product['price'] ?? ''), ENT_QUOTES, 'UTF-8');
+                    $image = htmlspecialchars((string) ($product['image'] ?? ''), ENT_QUOTES, 'UTF-8');
+                    $items[] = <<<HTML
+<li class="product">
+    <div class="product__image" style="background-image: url('{$image}');"></div>
+    <div class="product__body">
+        <h3>{$title}</h3>
+        <p class="product__price">{$price}</p>
+    </div>
+</li>
+HTML;
+                }
+
+                $itemsMarkup = $items === []
+                    ? '<li class="product product--empty">Products will appear here soon.</li>'
+                    : implode("\n", $items);
+
+                $this->tracker->recordEvent($context['user'] ?? 'guest', 'block.rendered', ['block' => 'core.product_grid']);
+
+                return <<<HTML
+<section class="block product-grid" id="products">
+    <h2>Featured products</h2>
+    <ul class="product-grid__items">
+        {$itemsMarkup}
+    </ul>
+</section>
+HTML;
+            },
+            schema: [
+                'products' => ['type' => 'collection', 'label' => 'Products'],
+            ],
+            defaultSettings: []
+        ));
+    }
+
+    public function boot(ContentManager $contentManager): void
+    {
+        $contentManager->definePage('home', [
+            'metadata' => [
+                'title' => 'Ricktorious Limited Storefront',
+                'description' => 'AI-personalised ecommerce blocks for the Ricktorious brand.',
+            ],
+            'blocks' => [
+                [
+                    'type' => 'core.hero',
+                    'settings' => [
+                        'heading' => 'The Ricktorious Experience',
+                        'subtitle' => 'Build an adaptive storefront in minutes with extension-ready blocks.',
+                        'cta_label' => 'View collection',
+                        'cta_url' => '#products',
+                    ],
+                ],
+                [
+                    'type' => 'core.product_grid',
+                    'settings' => [
+                        'products' => [
+                            [
+                                'title' => 'Ricktorious Modular Hoodie',
+                                'price' => '$89',
+                                'image' => 'https://picsum.photos/seed/ricktorious-hoodie/600/600',
+                            ],
+                            [
+                                'title' => 'Blockbuilder Sneakers',
+                                'price' => '$125',
+                                'image' => 'https://picsum.photos/seed/ricktorious-sneakers/600/600',
+                            ],
+                            [
+                                'title' => 'Adaptive Strategy Notebook',
+                                'price' => '$22',
+                                'image' => 'https://picsum.photos/seed/ricktorious-notebook/600/600',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function registerApis(AdhocApiRouter $router): void
+    {
+        $router->addRoute('GET', '/api/insights', function (array $query): array {
+            $user = (string) ($query['user'] ?? 'guest');
+            $insights = $this->personalization->insights($user);
+
+            return [
+                'status' => 200,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $insights,
+            ];
+        });
+    }
+}

--- a/src/Ricktorious/Ecommerce/bootstrap.php
+++ b/src/Ricktorious/Ecommerce/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/Core/BlockType.php';
+require_once __DIR__ . '/Core/BlockRegistry.php';
+require_once __DIR__ . '/Core/ContentManager.php';
+require_once __DIR__ . '/Core/ExtensionInterface.php';
+require_once __DIR__ . '/Core/AdhocApiRouter.php';
+require_once __DIR__ . '/Core/ExtensionManager.php';
+require_once __DIR__ . '/Core/Application.php';
+require_once __DIR__ . '/Analytics/UserBehaviorTracker.php';
+require_once __DIR__ . '/AI/PersonalizationEngine.php';
+require_once __DIR__ . '/Extensions/CoreContentExtension.php';

--- a/web/ricktorious.php
+++ b/web/ricktorious.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../src/Ricktorious/Ecommerce/bootstrap.php';
+
+use Ricktorious\Ecommerce\AI\PersonalizationEngine;
+use Ricktorious\Ecommerce\Analytics\UserBehaviorTracker;
+use Ricktorious\Ecommerce\Core\AdhocApiRouter;
+use Ricktorious\Ecommerce\Core\Application;
+use Ricktorious\Ecommerce\Core\BlockRegistry;
+use Ricktorious\Ecommerce\Core\ContentManager;
+use Ricktorious\Ecommerce\Core\ExtensionManager;
+use Ricktorious\Ecommerce\Extensions\CoreContentExtension;
+
+session_start();
+
+$userId = $_SESSION['ricktorious_user'] ?? null;
+if ($userId === null) {
+    $userId = 'user-' . bin2hex(random_bytes(4));
+    $_SESSION['ricktorious_user'] = $userId;
+}
+
+$blockRegistry = new BlockRegistry();
+$contentManager = new ContentManager();
+$extensionManager = new ExtensionManager();
+$behaviorTracker = new UserBehaviorTracker();
+$personalization = new PersonalizationEngine($behaviorTracker);
+$router = new AdhocApiRouter();
+
+$coreExtension = new CoreContentExtension($behaviorTracker, $personalization);
+$extensionManager->addExtension($coreExtension);
+
+$app = new Application(
+    $blockRegistry,
+    $contentManager,
+    $extensionManager,
+    $router,
+    $behaviorTracker,
+    $personalization
+);
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+$path = parse_url($uri, PHP_URL_PATH) ?: '/';
+
+if (str_starts_with($path, '/api/')) {
+    $query = $_GET;
+    $payload = $_POST;
+    $response = $app->handleApiRequest($method, $path, $query, $payload);
+
+    http_response_code($response['status']);
+    foreach ($response['headers'] as $name => $value) {
+        header($name . ': ' . $value);
+    }
+    echo json_encode($response['body'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$catalogue = [
+    ['title' => 'Ricktorious Modular Hoodie', 'price' => '$89', 'image' => 'https://picsum.photos/seed/ricktorious-hoodie/600/600'],
+    ['title' => 'Blockbuilder Sneakers', 'price' => '$125', 'image' => 'https://picsum.photos/seed/ricktorious-sneakers/600/600'],
+    ['title' => 'Adaptive Strategy Notebook', 'price' => '$22', 'image' => 'https://picsum.photos/seed/ricktorious-notebook/600/600'],
+    ['title' => 'AI Commerce Playbook', 'price' => '$42', 'image' => 'https://picsum.photos/seed/ricktorious-playbook/600/600'],
+];
+
+$app->boot();
+$page = $app->renderPage('home', [
+    'user' => $userId,
+    'products' => $catalogue,
+]);
+
+$recommended = $app->personalizationEngine()->recommendBlocks($userId, array_keys($blockRegistry->all()));
+$behaviorTracker->recordEvent($userId, 'page.view', ['page' => 'home']);
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title><?php echo htmlspecialchars($page['title'], ENT_QUOTES, 'UTF-8'); ?></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="<?php echo htmlspecialchars((string) ($page['metadata']['description'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+        }
+        body {
+            margin: 0;
+        }
+        header.hero-shell {
+            padding: 3rem 1rem 2rem;
+            background: radial-gradient(circle at top left, #38bdf8, #0f172a 55%);
+        }
+        .wrapper {
+            max-width: 1080px;
+            margin: 0 auto;
+            padding: 0 1.5rem 4rem;
+        }
+        .blocks {
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+        }
+        .block {
+            background: rgba(15, 23, 42, 0.75);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            border-radius: 16px;
+            padding: 2.5rem;
+            box-shadow: 0 20px 40px rgba(8, 47, 73, 0.3);
+        }
+        .block.hero {
+            background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(129, 140, 248, 0.15));
+        }
+        .block.hero h1 {
+            font-size: 2.75rem;
+            margin-bottom: 1rem;
+        }
+        .block.hero p {
+            margin-bottom: 1.5rem;
+            color: rgba(226, 232, 240, 0.85);
+        }
+        .block.hero .button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: #38bdf8;
+            color: #0f172a;
+            font-weight: 600;
+            padding: 0.85rem 1.75rem;
+            border-radius: 999px;
+            text-decoration: none;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 12px 24px rgba(56, 189, 248, 0.35);
+        }
+        .block.hero .button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 32px rgba(56, 189, 248, 0.45);
+        }
+        .product-grid h2 {
+            margin-bottom: 1.5rem;
+        }
+        .product-grid__items {
+            list-style: none;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 1.5rem;
+            padding: 0;
+            margin: 0;
+        }
+        .product {
+            background: rgba(15, 23, 42, 0.8);
+            border-radius: 18px;
+            overflow: hidden;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            display: flex;
+            flex-direction: column;
+            min-height: 280px;
+        }
+        .product__image {
+            background-size: cover;
+            background-position: center;
+            padding-top: 100%;
+        }
+        .product__body {
+            padding: 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .product__price {
+            color: #38bdf8;
+            font-weight: 600;
+        }
+        .insights {
+            margin-top: 3rem;
+            padding: 2rem;
+            border-radius: 16px;
+            background: rgba(15, 23, 42, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+        .insights h2 {
+            margin-top: 0;
+        }
+        code {
+            font-family: 'JetBrains Mono', SFMono-Regular, ui-monospace, monospace;
+            background: rgba(15, 23, 42, 0.85);
+            padding: 0.35rem 0.5rem;
+            border-radius: 8px;
+        }
+        footer {
+            margin-top: 4rem;
+            color: rgba(226, 232, 240, 0.55);
+            text-align: center;
+        }
+        @media (max-width: 640px) {
+            .block {
+                padding: 1.75rem;
+            }
+            .block.hero h1 {
+                font-size: 2.1rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header class="hero-shell">
+        <div class="wrapper">
+            <p style="margin: 0; letter-spacing: 0.2em; font-size: 0.75rem; text-transform: uppercase; color: rgba(226,232,240,0.6);">Ricktorious Limited</p>
+            <h1 style="margin: 0.5rem 0 0; font-size: 2.5rem;">Adaptive Ecommerce Playground</h1>
+            <p style="max-width: 520px; color: rgba(226,232,240,0.7);">
+                Extension-ready, block-based merchandising with an AI-first personalisation engine. Explore how the platform can learn from your audience and remix content automatically.
+            </p>
+        </div>
+    </header>
+    <main class="wrapper">
+        <section class="blocks">
+            <?php echo $page['html']; ?>
+        </section>
+        <section class="insights">
+            <h2>Live personalisation insights</h2>
+            <p>Your visitor ID: <code><?php echo htmlspecialchars($userId, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>Recommended block order: <code><?php echo htmlspecialchars(implode(', ', $recommended), ENT_QUOTES, 'UTF-8'); ?></code></p>
+            <p>Fetch full analytics via <code>/api/insights?user=<?php echo urlencode($userId); ?></code>.</p>
+        </section>
+        <footer>
+            <p>&copy; <?php echo date('Y'); ?> Ricktorious Limited. Building a self-optimising commerce platform.</p>
+        </footer>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Ricktorious ecommerce architecture vision document and README pointers
- scaffold block-based ecommerce kernel with extension, analytics, and AI layers
- deliver Ricktorious storefront front controller with insights API and hero/product blocks

## Testing
- php -l web/ricktorious.php
- php -l src/Ricktorious/Ecommerce/bootstrap.php
- php -l src/Ricktorious/Ecommerce/Core/Application.php
- php -l src/Ricktorious/Ecommerce/Core/BlockType.php
- php -l src/Ricktorious/Ecommerce/Core/BlockRegistry.php
- php -l src/Ricktorious/Ecommerce/Core/ContentManager.php
- php -l src/Ricktorious/Ecommerce/Core/ExtensionInterface.php
- php -l src/Ricktorious/Ecommerce/Core/AdhocApiRouter.php
- php -l src/Ricktorious/Ecommerce/Core/ExtensionManager.php
- php -l src/Ricktorious/Ecommerce/AI/PersonalizationEngine.php
- php -l src/Ricktorious/Ecommerce/Analytics/UserBehaviorTracker.php
- php -l src/Ricktorious/Ecommerce/Extensions/CoreContentExtension.php

------
https://chatgpt.com/codex/tasks/task_e_68e628da88308327a64106e09d5d9461