### PR TITLE
Create Ricktorious storefront and expand commerce APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,5 +164,16 @@ Then browse to `http://localhost:8000/ricktorious.php` to explore:
   with draft saving, publication workflows, and revision history accessible via
   the enhanced in-memory content manager.
 
+### Headless storefront
+
+The `web/storefront.php` single-page experience consumes the commerce APIs to
+deliver a fully interactive storefront for Ricktorious Limited. Start the same
+development server and open `http://localhost:8000/storefront.php` to try:
+
+- Dynamic catalogue rendering powered by `/api/catalog/products`.
+- Cart and checkout orchestration via `/api/cart/*` and `/api/checkout`.
+- Behavioural telemetry surfaced from `/api/insights` alongside the
+  `/api/analytics/events` endpoint for recording frontend interactions.
+
 Consult `docs/ricktorious-ecommerce.md` for an overview of the platform
 architecture and extension system.

--- a/src/Ricktorious/Ecommerce/Extensions/CommerceExtension.php
+++ b/src/Ricktorious/Ecommerce/Extensions/CommerceExtension.php
@@ -56,26 +56,10 @@ final class CommerceExtension implements ExtensionInterface
         });
 
         $router->addRoute('GET', '/api/cart/summary', function (): array {
-            $items = [];
-            foreach ($this->cart->detailedItems($this->products) as $item) {
-                $product = $item['product'];
-                $items[] = [
-                    'product' => $product->toArray(),
-                    'quantity' => $item['quantity'],
-                    'line_total' => $item['line_total'],
-                ];
-            }
-
-            $total = $this->cart->total($this->products);
-
             return [
                 'status' => 200,
                 'headers' => ['Content-Type' => 'application/json'],
-                'body' => [
-                    'items' => $items,
-                    'total' => $total,
-                    'formatted_total' => '$' . number_format($total, 2),
-                ],
+                'body' => $this->cartSummary(),
             ];
         });
 
@@ -97,6 +81,7 @@ final class CommerceExtension implements ExtensionInterface
                 'product' => $product->id(),
                 'quantity' => $quantity,
                 'channel' => 'api',
+                'block' => 'api.cart',
             ]);
 
             return [
@@ -105,7 +90,75 @@ final class CommerceExtension implements ExtensionInterface
                 'body' => [
                     'message' => 'Product added to cart',
                     'cart' => $this->cart->toArray(),
+                    'summary' => $this->cartSummary(),
                 ],
+            ];
+        });
+
+        $router->addRoute('POST', '/api/cart/update', function (array $query, array $payload): array {
+            $items = (array) ($payload['items'] ?? []);
+            foreach ($items as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+
+                $productId = (string) ($entry['product'] ?? '');
+                if ($productId === '') {
+                    continue;
+                }
+
+                $quantity = (int) ($entry['quantity'] ?? 0);
+                $this->cart->updateQuantity($productId, $quantity);
+            }
+
+            $this->tracker->recordEvent($query['user'] ?? 'guest', 'cart.updated', [
+                'items' => $this->cart->items(),
+                'channel' => 'api',
+                'block' => 'api.cart',
+            ]);
+
+            return [
+                'status' => 200,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $this->cartSummary(),
+            ];
+        });
+
+        $router->addRoute('POST', '/api/cart/remove', function (array $query, array $payload): array {
+            $productId = (string) ($payload['product'] ?? '');
+            if ($productId === '') {
+                return [
+                    'status' => 422,
+                    'headers' => ['Content-Type' => 'application/json'],
+                    'body' => ['error' => 'product is required'],
+                ];
+            }
+
+            $this->cart->removeProduct($productId);
+            $this->tracker->recordEvent($query['user'] ?? 'guest', 'cart.removed', [
+                'product' => $productId,
+                'channel' => 'api',
+                'block' => 'api.cart',
+            ]);
+
+            return [
+                'status' => 200,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $this->cartSummary(),
+            ];
+        });
+
+        $router->addRoute('POST', '/api/cart/clear', function (array $query): array {
+            $this->cart->clear();
+            $this->tracker->recordEvent($query['user'] ?? 'guest', 'cart.cleared', [
+                'channel' => 'api',
+                'block' => 'api.cart',
+            ]);
+
+            return [
+                'status' => 200,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => $this->cartSummary(),
             ];
         });
 
@@ -131,6 +184,8 @@ final class CommerceExtension implements ExtensionInterface
             $this->tracker->recordEvent($query['user'] ?? 'guest', 'order.completed', [
                 'order' => $order['id'],
                 'total' => $order['total'],
+                'channel' => 'api',
+                'block' => 'api.checkout',
             ]);
             $this->cart->clear();
 
@@ -140,5 +195,52 @@ final class CommerceExtension implements ExtensionInterface
                 'body' => $order,
             ];
         });
+
+        $router->addRoute('POST', '/api/analytics/events', function (array $query, array $payload): array {
+            $event = trim((string) ($payload['event'] ?? ''));
+            if ($event === '') {
+                return [
+                    'status' => 422,
+                    'headers' => ['Content-Type' => 'application/json'],
+                    'body' => ['error' => 'event is required'],
+                ];
+            }
+
+            $metadata = (array) ($payload['payload'] ?? []);
+            $this->tracker->recordEvent($query['user'] ?? 'guest', $event, $metadata);
+
+            return [
+                'status' => 204,
+                'headers' => ['Content-Type' => 'application/json'],
+                'body' => null,
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cartSummary(): array
+    {
+        $items = [];
+        foreach ($this->cart->detailedItems($this->products) as $item) {
+            $product = $item['product'];
+            $lineTotal = (float) $item['line_total'];
+            $items[] = [
+                'product' => $product->toArray(),
+                'quantity' => $item['quantity'],
+                'line_total' => $lineTotal,
+                'formatted_line_total' => '$' . number_format($lineTotal, 2),
+            ];
+        }
+
+        $total = $this->cart->total($this->products);
+
+        return [
+            'items' => $items,
+            'total' => $total,
+            'formatted_total' => '$' . number_format($total, 2),
+            'item_count' => $this->cart->itemCount(),
+        ];
     }
 }

--- a/web/assets/app.js
+++ b/web/assets/app.js
@@ -1,813 +1,545 @@
-const products = [
-  {
-    id: 'aurora-knit-sneaker',
-    name: 'Aurora Knit Sneaker',
-    category: 'footwear',
-    price: 188,
-    rating: 4.8,
-    reviews: 184,
-    description: 'Seamless knit sneaker with adaptive cushioning and algae-based foam outsole.',
-    longDescription:
-      'Engineered for urban exploration with breathable knit uppers, algae-based midsoles, and reflective detailing for late night commutes.',
-    badges: ['New', 'Bestseller'],
-    popularity: 98,
-    releaseDate: '2024-03-22',
-    colors: [
-      { name: 'Glacier', value: '#dce4f7' },
-      { name: 'Nebula', value: '#1f2937' },
-      { name: 'Copper', value: '#b45309' }
-    ],
-    sizes: ['US 6', 'US 7', 'US 8', 'US 9', 'US 10', 'US 11'],
-    media: [
-      'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1517070208541-6ddc4d3efbcb?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'solace-trench',
-    name: 'Solace Technical Trench',
-    category: 'apparel',
-    price: 248,
-    rating: 4.7,
-    reviews: 92,
-    description: 'Weatherproof trench crafted with recycled nylon and heat-sealed seams.',
-    longDescription:
-      'A breathable three-layer shell with detachable hood, magnetic closures, and reflective piping for seamless day-to-night transitions.',
-    badges: ['Limited'],
-    popularity: 87,
-    releaseDate: '2024-01-10',
-    colors: [
-      { name: 'Storm', value: '#1f2937' },
-      { name: 'Sandstone', value: '#d6b98c' }
-    ],
-    sizes: ['XS', 'S', 'M', 'L', 'XL'],
-    media: [
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1507679799987-c73779587ccf?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1490481651871-ab68de25d43d?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'flux-backpack',
-    name: 'Flux Modular Backpack',
-    category: 'accessories',
-    price: 198,
-    rating: 4.9,
-    reviews: 241,
-    description: 'Magnetic modular compartments with wireless charging dock and RFID shielding.',
-    longDescription:
-      'Customize storage with swappable modules, fast access laptop sleeve, and integrated wireless charger powered by solar top panel.',
-    badges: ['Top Rated'],
-    popularity: 95,
-    releaseDate: '2023-11-15',
-    colors: [
-      { name: 'Graphite', value: '#111827' },
-      { name: 'Slate', value: '#374151' }
-    ],
-    sizes: ['18L', '24L'],
-    media: [
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1531259683007-016a7b628fc3?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1529338296731-c4280a44fc47?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'lumina-lamp',
-    name: 'Lumina Adaptive Lamp',
-    category: 'smart-living',
-    price: 162,
-    rating: 4.6,
-    reviews: 146,
-    description: 'Smart lighting that tracks circadian rhythms and syncs with ambient audio.',
-    longDescription:
-      'Tuneable LED array with biometrics integration, voice control, and automatic brightness mapping across 360° rotation.',
-    badges: ['Smart Home'],
-    popularity: 82,
-    releaseDate: '2023-09-05',
-    colors: [
-      { name: 'Polar', value: '#f3f4f6' },
-      { name: 'Obsidian', value: '#0f172a' }
-    ],
-    sizes: ['Standard'],
-    media: [
-      'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1524758631624-e2822e304c36?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'zenith-coat',
-    name: 'Zenith Merino Coat',
-    category: 'apparel',
-    price: 320,
-    rating: 4.9,
-    reviews: 68,
-    description: 'Double-faced merino with thermoregulating lining and invisible pockets.',
-    longDescription:
-      'Hand finished merino panels with tonal taping, convertible collar, and heat-mapped interior quilting for maximal comfort.',
-    badges: ['Editors’ Pick'],
-    popularity: 76,
-    releaseDate: '2023-12-01',
-    colors: [
-      { name: 'Charcoal', value: '#111827' },
-      { name: 'Oat', value: '#d6d3ce' }
-    ],
-    sizes: ['XS', 'S', 'M', 'L', 'XL'],
-    media: [
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1521676259650-675b5bfec8e1?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1542293787938-4d2226e676d3?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'pulse-earbuds',
-    name: 'Pulse Noise-Cancelling Earbuds',
-    category: 'accessories',
-    price: 248,
-    rating: 4.7,
-    reviews: 302,
-    description: 'Hi-res audio with adaptive transparency mode and wireless Qi charging case.',
-    longDescription:
-      'Carbon composite drivers tuned by award-winning engineers, wind reduction microphones, and 32-hour battery life.',
-    badges: ['Limited', 'Smart Audio'],
-    popularity: 91,
-    releaseDate: '2024-02-18',
-    colors: [
-      { name: 'Matte Black', value: '#111827' },
-      { name: 'Moonstone', value: '#d1d5db' }
-    ],
-    sizes: ['Universal'],
-    media: [
-      'https://images.unsplash.com/photo-1516116216624-53e697fedbea?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1519205080495-3d97d1e28d90?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1524678606370-a47ad25cb82a?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'haven-throw',
-    name: 'Haven Cashmere Throw',
-    category: 'smart-living',
-    price: 148,
-    rating: 4.5,
-    reviews: 77,
-    description: 'Traceable cashmere throw infused with temperature balancing minerals.',
-    longDescription:
-      'Sustainably sourced fibers woven with phase-change minerals to keep you cool or cozy, plus stain resistant nano-coating.',
-    badges: ['Sustainable'],
-    popularity: 70,
-    releaseDate: '2023-10-09',
-    colors: [
-      { name: 'Mist', value: '#e5e7eb' },
-      { name: 'Sea', value: '#0ea5e9' }
-    ],
-    sizes: ['50" × 70"'],
-    media: [
-      'https://images.unsplash.com/photo-1524758631624-e2822e304c36?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1521590832167-7bcbfaa6381f?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1530023367847-a683933f4177?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'atlas-desk',
-    name: 'Atlas Sit-Stand Desk',
-    category: 'smart-living',
-    price: 540,
-    rating: 4.8,
-    reviews: 119,
-    description: 'Smart desk with biometric presets, cable passthrough, and wireless charging surface.',
-    longDescription:
-      'Solid ash desktop with whisper-quiet motors, dual-zone wireless chargers, and health analytics that sync to the Nova app.',
-    badges: ['Pro Studio'],
-    popularity: 89,
-    releaseDate: '2023-08-21',
-    colors: [
-      { name: 'Warm Ash', value: '#cbb69b' },
-      { name: 'Onyx', value: '#1f2937' }
-    ],
-    sizes: ['48"', '60"', '72"'],
-    media: [
-      'https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1487017159836-4e23ece2e4cf?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'stride-runner',
-    name: 'Stride Runner V2',
-    category: 'footwear',
-    price: 168,
-    rating: 4.4,
-    reviews: 214,
-    description: 'Dual-density cushioning with energy return plate and reflective panelling.',
-    longDescription:
-      'Performance-forward trainer built with recycled mesh, water repellent nano-coating, and energy return composite plate.',
-    badges: ['Run Club'],
-    popularity: 74,
-    releaseDate: '2023-11-30',
-    colors: [
-      { name: 'Signal', value: '#dc2626' },
-      { name: 'Frost', value: '#cbd5f5' }
-    ],
-    sizes: ['US 6', 'US 7', 'US 8', 'US 9', 'US 10', 'US 11', 'US 12'],
-    media: [
-      'https://images.unsplash.com/photo-1483721310020-03333e577078?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1511556820780-d912e42b4980?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1487956382158-bb926046304a?auto=format&fit=crop&w=900&q=80'
-    ]
-  },
-  {
-    id: 'equilibrium-mat',
-    name: 'Equilibrium Performance Mat',
-    category: 'accessories',
-    price: 128,
-    rating: 4.6,
-    reviews: 64,
-    description: 'Grippy bio-based mat with antimicrobial finish and laser alignment guides.',
-    longDescription:
-      'Crafted with FSC-certified natural rubber, closed-cell top layer, and dual alignment systems for mindful movement.',
-    badges: ['Wellness'],
-    popularity: 66,
-    releaseDate: '2024-02-02',
-    colors: [
-      { name: 'Eucalyptus', value: '#6ee7b7' },
-      { name: 'Night', value: '#0f172a' }
-    ],
-    sizes: ['Standard'],
-    media: [
-      'https://images.unsplash.com/photo-1548697143-8f0a5f1c9c55?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1517964603305-11c0f1f6c63c?auto=format&fit=crop&w=900&q=80',
-      'https://images.unsplash.com/photo-1526401281623-359d82f9a5a0?auto=format&fit=crop&w=900&q=80'
-    ]
-  }
-];
+const API_BASE = '/ricktorious.php';
+const endpoints = {
+  products: `${API_BASE}/api/catalog/products`,
+  cartSummary: `${API_BASE}/api/cart/summary`,
+  cartAdd: `${API_BASE}/api/cart/add`,
+  cartUpdate: `${API_BASE}/api/cart/update`,
+  cartRemove: `${API_BASE}/api/cart/remove`,
+  cartClear: `${API_BASE}/api/cart/clear`,
+  checkout: `${API_BASE}/api/checkout`,
+  insights: `${API_BASE}/api/insights`,
+  analytics: `${API_BASE}/api/analytics/events`
+};
 
 const state = {
-  category: 'all',
-  search: '',
-  sort: 'featured',
-  maxPrice: 600,
-  cart: [],
-  theme: 'light'
+  products: [],
+  filters: {
+    search: '',
+    tag: 'all'
+  },
+  cart: {
+    items: [],
+    total: 0,
+    formatted_total: '$0.00',
+    item_count: 0
+  }
 };
 
-const grid = document.getElementById('product-grid');
-const emptyState = document.getElementById('empty-state');
-const priceRange = document.getElementById('price-range');
-const priceValue = document.getElementById('price-value');
-const sortSelect = document.getElementById('sort-select');
-const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
-const searchInputs = [
-  document.getElementById('inline-search'),
-  document.getElementById('global-search')
-].filter(Boolean);
-const cartToggle = document.getElementById('cart-toggle');
-const cartPanel = document.getElementById('cart-panel');
-const cartClose = document.getElementById('cart-close');
-const cartItems = document.getElementById('cart-items');
-const cartCount = document.getElementById('cart-count');
-const cartSubtotal = document.getElementById('cart-subtotal');
-const cartEmpty = document.getElementById('cart-empty');
-const resetFilters = document.getElementById('reset-filters');
-const checkoutButton = document.getElementById('checkout-button');
-const themeToggle = document.getElementById('theme-toggle');
-const searchToggle = document.getElementById('search-toggle');
-const searchPanel = document.getElementById('search-panel');
-const searchClose = document.getElementById('search-close');
-const mobileMenuToggle = document.getElementById('mobile-menu');
-const mainNav = document.querySelector('.main-nav');
-const newsletterForm = document.getElementById('newsletter-form');
-const newsletterFeedback = document.getElementById('newsletter-feedback');
-const modal = document.getElementById('product-modal');
-const modalBackdrop = document.getElementById('modal-backdrop');
-const modalClose = document.getElementById('modal-close');
-const modalImage = document.getElementById('modal-image');
-const modalThumbnails = document.getElementById('modal-thumbnails');
-const modalTitle = document.getElementById('modal-title');
-const modalPrice = document.getElementById('modal-price');
-const modalDescription = document.getElementById('modal-description');
-const modalColors = document.getElementById('modal-colors');
-const modalSizes = document.getElementById('modal-sizes');
-const modalAdd = document.getElementById('modal-add');
-
-let modalState = {
-  productId: null,
-  color: null,
-  size: null
+const els = {
+  productGrid: document.getElementById('product-grid'),
+  emptyState: document.getElementById('empty-state'),
+  searchInput: document.getElementById('search-input'),
+  tagFilter: document.getElementById('tag-filter'),
+  resetFilters: document.getElementById('reset-filters'),
+  cartButton: document.getElementById('cart-button'),
+  cartOverlay: document.getElementById('cart-overlay'),
+  cartBody: document.getElementById('cart-body'),
+  cartTotal: document.getElementById('cart-total'),
+  cartCount: document.getElementById('cart-count'),
+  cartClose: document.getElementById('cart-close'),
+  cartClear: document.getElementById('cart-clear'),
+  cartCheckout: document.getElementById('cart-checkout'),
+  checkoutForm: document.getElementById('checkout-form'),
+  checkoutMessages: document.getElementById('checkout-messages'),
+  toast: document.getElementById('app-toast'),
+  insightEvents: document.getElementById('insight-events'),
+  insightBlocks: document.getElementById('insight-blocks')
 };
 
-function loadPersistedState() {
-  try {
-    const storedCart = localStorage.getItem('nova-cart');
-    if (storedCart) {
-      state.cart = JSON.parse(storedCart);
-    }
-  } catch (error) {
-    console.warn('Unable to load cart from storage', error);
-  }
+let toastTimeout;
 
-  try {
-    const storedTheme = localStorage.getItem('nova-theme');
-    if (storedTheme === 'dark') {
-      state.theme = 'dark';
-      document.body.classList.add('dark');
-    }
-  } catch (error) {
-    console.warn('Unable to load theme from storage', error);
-  }
-
-  updateThemeIcon();
-}
-
-function persistCart() {
-  try {
-    localStorage.setItem('nova-cart', JSON.stringify(state.cart));
-  } catch (error) {
-    console.warn('Unable to persist cart', error);
-  }
-}
-
-function persistTheme() {
-  try {
-    localStorage.setItem('nova-theme', state.theme);
-  } catch (error) {
-    console.warn('Unable to persist theme', error);
-  }
-}
-
-function formatPrice(value) {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD'
-  }).format(value);
-}
-
-function renderProducts() {
-  grid.innerHTML = '';
-  const filtered = products
-    .filter((product) => {
-      const matchesCategory = state.category === 'all' || product.category === state.category;
-      const matchesSearch = state.search === ''
-        || product.name.toLowerCase().includes(state.search)
-        || product.description.toLowerCase().includes(state.search);
-      const matchesPrice = product.price <= state.maxPrice;
-      return matchesCategory && matchesSearch && matchesPrice;
-    })
-    .sort((a, b) => sortProducts(a, b));
-
-  if (filtered.length === 0) {
-    emptyState.hidden = false;
-    grid.style.display = 'none';
+function showToast(message, tone = 'info') {
+  if (!els.toast) {
     return;
   }
 
-  emptyState.hidden = true;
-  grid.style.display = '';
-
-  for (const product of filtered) {
-    grid.appendChild(createProductCard(product));
-  }
+  els.toast.textContent = message;
+  els.toast.dataset.tone = tone;
+  els.toast.hidden = false;
+  clearTimeout(toastTimeout);
+  toastTimeout = window.setTimeout(() => {
+    els.toast.hidden = true;
+  }, 3600);
 }
 
-function sortProducts(a, b) {
-  switch (state.sort) {
-    case 'newest':
-      return new Date(b.releaseDate) - new Date(a.releaseDate);
-    case 'price-asc':
-      return a.price - b.price;
-    case 'price-desc':
-      return b.price - a.price;
-    case 'rating':
-      return b.rating - a.rating;
-    default:
-      return b.popularity - a.popularity;
+async function request(url, options = {}) {
+  const opts = {
+    headers: {
+      'Accept': 'application/json'
+    },
+    ...options
+  };
+
+  if (opts.body && typeof opts.body !== 'string') {
+    opts.headers['Content-Type'] = 'application/json';
+    opts.body = JSON.stringify(opts.body);
   }
+
+  const response = await fetch(url, opts);
+  let data = null;
+
+  if (response.status !== 204) {
+    try {
+      data = await response.json();
+    } catch (error) {
+      data = null;
+    }
+  }
+
+  if (!response.ok) {
+    const message = data && typeof data.error === 'string' ? data.error : 'Request failed';
+    throw new Error(message);
+  }
+
+  return data;
 }
 
-function createProductCard(product) {
-  const card = document.createElement('article');
-  card.className = 'product-card';
+function productMatchesFilters(product) {
+  const search = state.filters.search.trim().toLowerCase();
+  const tag = state.filters.tag;
+  const name = (product.name || '').toLowerCase();
+  const description = (product.description || '').toLowerCase();
+  const tags = Array.isArray(product.tags) ? product.tags : [];
 
-  const badgeMarkup = product.badges
-    .map((badge) => `<span class="badge">${badge}</span>`)
-    .join('');
+  const matchesSearch = search === '' || name.includes(search) || description.includes(search);
+  const matchesTag = tag === 'all' || tags.includes(tag);
 
-  card.innerHTML = `
-    <div class="product-media">
-      <img src="${product.media[0]}" alt="${product.name}">
-      <div class="product-badges">${badgeMarkup}</div>
-    </div>
-    <div class="product-body">
-      <h3>${product.name}</h3>
-      <p>${product.description}</p>
-      <div class="product-meta">
-        <span class="price">${formatPrice(product.price)}</span>
-        <span class="rating">
-          <span class="rating-stars">${renderStars(product.rating)}</span>
-          <span>${product.rating.toFixed(1)}</span>
-        </span>
+  return matchesSearch && matchesTag;
+}
+
+function formatCurrency(value, currency = '$') {
+  const amount = Number.isFinite(value) ? Number(value) : 0;
+  return `${currency}${amount.toFixed(2)}`;
+}
+
+function buildProductCard(product) {
+  const image = Array.isArray(product.images) && product.images.length > 0
+    ? product.images[0]
+    : 'https://picsum.photos/seed/ricktorious-default/600/600';
+
+  const tags = Array.isArray(product.tags) ? product.tags : [];
+  const tagHtml = tags.map(tag => `<span class="pill">${escapeHtml(tag)}</span>`).join('');
+
+  return `
+    <article class="product-card">
+      <div class="product-media" style="background-image: url('${escapeHtml(image)}');"></div>
+      <div class="product-body">
+        <h3>${escapeHtml(product.name || 'Untitled product')}</h3>
+        <p class="product-description">${escapeHtml(product.description || '')}</p>
+        <div class="product-meta">
+          <span class="price">${escapeHtml(product.formatted_price || formatCurrency(product.price, product.currency))}</span>
+          <div class="product-tags">${tagHtml}</div>
+        </div>
+        <button type="button" class="button primary add-to-cart" data-product="${escapeHtml(product.id)}">Add to cart</button>
       </div>
-      <div class="card-footer">
-        <button class="button primary add-to-cart" type="button">Add to bag</button>
-        <button class="quick-view" type="button">Quick view</button>
-      </div>
-    </div>
+    </article>
   `;
+}
 
-  card.querySelector('.add-to-cart')?.addEventListener('click', () => {
-    const color = product.colors[0]?.name ?? 'Default';
-    const size = product.sizes[0] ?? 'One size';
-    addToCart(product, { color, size });
-    openCart();
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderProducts() {
+  if (!els.productGrid || !els.emptyState) {
+    return;
+  }
+
+  const filtered = state.products.filter(productMatchesFilters);
+
+  if (filtered.length === 0) {
+    els.productGrid.innerHTML = '';
+    els.emptyState.hidden = false;
+    return;
+  }
+
+  els.emptyState.hidden = true;
+  els.productGrid.innerHTML = filtered.map(buildProductCard).join('');
+
+  els.productGrid.querySelectorAll('.add-to-cart').forEach(button => {
+    button.addEventListener('click', async (event) => {
+      const target = event.currentTarget;
+      const productId = target.dataset.product;
+      if (!productId) {
+        return;
+      }
+
+      target.disabled = true;
+      try {
+        await addToCart(productId);
+        showToast('Added to cart');
+      } catch (error) {
+        showToast(error.message, 'error');
+      } finally {
+        target.disabled = false;
+      }
+    });
+  });
+}
+
+function updateTagFilterOptions() {
+  if (!els.tagFilter) {
+    return;
+  }
+
+  const tags = new Set();
+  state.products.forEach(product => {
+    if (Array.isArray(product.tags)) {
+      product.tags.forEach(tag => tags.add(tag));
+    }
   });
 
-  const quickView = card.querySelector('.quick-view');
-  if (quickView) {
-    quickView.addEventListener('click', () => openModal(product.id));
-  }
+  const current = els.tagFilter.value;
+  els.tagFilter.innerHTML = '<option value="all">All categories</option>' +
+    Array.from(tags).sort().map(tag => `<option value="${escapeHtml(tag)}">${escapeHtml(tag)}</option>`).join('');
 
-  card.querySelector('.product-media img')?.addEventListener('click', () => openModal(product.id));
-
-  return card;
-}
-
-function renderStars(value) {
-  const rounded = Math.round(value);
-  return Array.from({ length: 5 })
-    .map((_, index) => `<span class="star ${index < rounded ? 'filled' : ''}"></span>`)
-    .join('');
-}
-
-function addToCart(product, options) {
-  const key = `${product.id}:${options.color}:${options.size}`;
-  const existing = state.cart.find((item) => item.key === key);
-
-  if (existing) {
-    existing.quantity += 1;
+  if (Array.from(tags).includes(current)) {
+    els.tagFilter.value = current;
   } else {
-    state.cart.push({
-      key,
-      id: product.id,
-      name: product.name,
-      price: product.price,
-      color: options.color,
-      size: options.size,
-      image: product.media[0],
-      quantity: 1
-    });
-  }
-
-  renderCart();
-  persistCart();
-}
-
-function removeFromCart(key) {
-  state.cart = state.cart.filter((item) => item.key !== key);
-  renderCart();
-  persistCart();
-}
-
-function updateCartQuantity(key, delta) {
-  const item = state.cart.find((entry) => entry.key === key);
-  if (!item) return;
-
-  item.quantity += delta;
-  if (item.quantity <= 0) {
-    removeFromCart(key);
-  } else {
-    renderCart();
-    persistCart();
+    els.tagFilter.value = 'all';
+    state.filters.tag = 'all';
   }
 }
 
 function renderCart() {
-  cartItems.innerHTML = '';
-  if (state.cart.length === 0) {
-    cartPanel.classList.add('empty');
-    cartEmpty.hidden = false;
-  } else {
-    cartPanel.classList.remove('empty');
-    cartEmpty.hidden = true;
-  }
-
-  let subtotal = 0;
-  let totalCount = 0;
-
-  for (const item of state.cart) {
-    subtotal += item.price * item.quantity;
-    totalCount += item.quantity;
-    cartItems.appendChild(createCartItem(item));
-  }
-
-  cartSubtotal.textContent = formatPrice(subtotal);
-  cartCount.textContent = String(totalCount);
-}
-
-function createCartItem(item) {
-  const li = document.createElement('li');
-  li.className = 'cart-item';
-  li.innerHTML = `
-    <img src="${item.image}" alt="${item.name}">
-    <div>
-      <h4>${item.name}</h4>
-      <p>${item.color} · ${item.size}</p>
-      <div class="cart-meta">
-        <div class="quantity-control" role="group" aria-label="Quantity">
-          <button type="button" aria-label="Decrease quantity">−</button>
-          <span>${item.quantity}</span>
-          <button type="button" aria-label="Increase quantity">+</button>
-        </div>
-        <strong>${formatPrice(item.price * item.quantity)}</strong>
-      </div>
-      <button class="quick-view" type="button">Remove</button>
-    </div>
-  `;
-
-  const [decrease, , increase] = li.querySelectorAll('button');
-  decrease.addEventListener('click', () => updateCartQuantity(item.key, -1));
-  increase.addEventListener('click', () => updateCartQuantity(item.key, 1));
-
-  const remove = li.querySelector('.quick-view');
-  remove?.addEventListener('click', () => removeFromCart(item.key));
-
-  return li;
-}
-
-function openCart() {
-  cartPanel.classList.add('active');
-  cartToggle?.setAttribute('aria-expanded', 'true');
-  cartPanel.setAttribute('aria-hidden', 'false');
-}
-
-function closeCart() {
-  cartPanel.classList.remove('active');
-  cartToggle?.setAttribute('aria-expanded', 'false');
-  cartPanel.setAttribute('aria-hidden', 'true');
-}
-
-function openSearch() {
-  searchPanel?.classList.add('active');
-  searchPanel?.setAttribute('aria-hidden', 'false');
-  const globalSearch = document.getElementById('global-search');
-  globalSearch?.focus();
-}
-
-function closeSearch() {
-  searchPanel?.classList.remove('active');
-  searchPanel?.setAttribute('aria-hidden', 'true');
-}
-
-function updateThemeIcon() {
-  const icon = themeToggle?.querySelector('.icon');
-  if (!icon) return;
-  icon.classList.remove('icon-sun', 'icon-moon');
-  icon.classList.add(state.theme === 'dark' ? 'icon-moon' : 'icon-sun');
-}
-
-function toggleTheme() {
-  state.theme = state.theme === 'dark' ? 'light' : 'dark';
-  document.body.classList.toggle('dark', state.theme === 'dark');
-  updateThemeIcon();
-  persistTheme();
-}
-
-function syncSearchInputs(value) {
-  for (const input of searchInputs) {
-    if (document.activeElement !== input) {
-      input.value = value;
-    }
-  }
-}
-
-function setupFilters() {
-  tabButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      tabButtons.forEach((btn) => {
-        btn.classList.remove('active');
-        btn.setAttribute('aria-selected', 'false');
-      });
-      button.classList.add('active');
-      button.setAttribute('aria-selected', 'true');
-      state.category = button.dataset.category ?? 'all';
-      renderProducts();
-    });
-  });
-
-  searchInputs.forEach((input) => {
-    input.addEventListener('input', (event) => {
-      const value = event.target.value.trim().toLowerCase();
-      state.search = value;
-      syncSearchInputs(event.target.value);
-      renderProducts();
-    });
-  });
-
-  sortSelect?.addEventListener('change', (event) => {
-    state.sort = event.target.value;
-    renderProducts();
-  });
-
-  priceRange?.addEventListener('input', (event) => {
-    const value = Number(event.target.value);
-    const ceiling = Number(priceRange.max ?? 600);
-    state.maxPrice = value;
-    priceValue.textContent = value >= ceiling ? `Up to ${formatPrice(ceiling)}+` : `Up to ${formatPrice(value)}`;
-    renderProducts();
-  });
-
-  resetFilters?.addEventListener('click', () => {
-    state.category = 'all';
-    state.search = '';
-    state.sort = 'featured';
-    state.maxPrice = Number(priceRange?.max ?? 600);
-    tabButtons.forEach((btn) => {
-      btn.classList.toggle('active', btn.dataset.category === 'all');
-      btn.setAttribute('aria-selected', btn.dataset.category === 'all' ? 'true' : 'false');
-    });
-    syncSearchInputs('');
-    if (sortSelect) sortSelect.value = 'featured';
-    if (priceRange) priceRange.value = priceRange.max ?? 600;
-    const ceiling = Number(priceRange?.max ?? 600);
-    priceValue.textContent = `Up to ${formatPrice(ceiling)}+`;
-    renderProducts();
-  });
-}
-
-function setupCart() {
-  cartToggle?.addEventListener('click', () => {
-    const expanded = cartPanel.classList.toggle('active');
-    cartToggle.setAttribute('aria-expanded', String(expanded));
-    cartPanel.setAttribute('aria-hidden', expanded ? 'false' : 'true');
-  });
-
-  cartClose?.addEventListener('click', () => closeCart());
-
-  checkoutButton?.addEventListener('click', () => {
-    if (state.cart.length === 0) {
-      alert('Add items to your bag before checking out.');
-      return;
-    }
-    alert('Secure checkout is coming soon. Your cart is saved for later!');
-  });
-}
-
-function setupSearchPanel() {
-  searchToggle?.addEventListener('click', () => {
-    const isOpen = searchPanel?.classList.contains('active');
-    if (isOpen) {
-      closeSearch();
-    } else {
-      openSearch();
-    }
-  });
-
-  searchClose?.addEventListener('click', () => closeSearch());
-  searchPanel?.addEventListener('click', (event) => {
-    if (event.target === searchPanel) {
-      closeSearch();
-    }
-  });
-}
-
-function setupMobileNav() {
-  mobileMenuToggle?.addEventListener('click', () => {
-    const isOpen = mainNav?.classList.toggle('open');
-    mobileMenuToggle.setAttribute('aria-expanded', String(Boolean(isOpen)));
-  });
-
-  mainNav?.querySelectorAll('a').forEach((link) => {
-    link.addEventListener('click', () => {
-      mainNav.classList.remove('open');
-      mobileMenuToggle?.setAttribute('aria-expanded', 'false');
-    });
-  });
-}
-
-function setupNewsletter() {
-  newsletterForm?.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const emailField = event.target.elements.email;
-    const email = emailField?.value.trim();
-    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      newsletterFeedback.textContent = 'Enter a valid email to join the list.';
-      newsletterFeedback.style.color = '#f97316';
-      return;
-    }
-
-    newsletterFeedback.textContent = 'You\'re in! Expect a welcome note shortly.';
-    newsletterFeedback.style.color = 'var(--accent-strong)';
-    event.target.reset();
-  });
-}
-
-function openModal(productId) {
-  const product = products.find((item) => item.id === productId);
-  if (!product) return;
-
-  modalState = {
-    productId: product.id,
-    color: product.colors[0]?.name ?? null,
-    size: product.sizes[0] ?? null
-  };
-
-  modalTitle.textContent = product.name;
-  modalPrice.textContent = formatPrice(product.price);
-  modalDescription.textContent = product.longDescription;
-  updateModalGallery(product.media);
-  updateModalOptions(modalColors, product.colors, modalState.color, (color) => {
-    modalState.color = color;
-  });
-  updateModalOptions(modalSizes, product.sizes, modalState.size, (size) => {
-    modalState.size = size;
-  });
-
-  modal.classList.add('active');
-  modal.setAttribute('aria-hidden', 'false');
-}
-
-function closeModal() {
-  modal.classList.remove('active');
-  modal.setAttribute('aria-hidden', 'true');
-}
-
-function updateModalGallery(images) {
-  modalImage.src = images[0];
-  modalImage.alt = 'Product preview';
-  modalThumbnails.innerHTML = '';
-
-  images.forEach((src, index) => {
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = `thumbnail${index === 0 ? ' active' : ''}`;
-    button.innerHTML = `<img src="${src}" alt="Thumbnail ${index + 1}">`;
-    button.addEventListener('click', () => {
-      modalImage.src = src;
-      modalThumbnails.querySelectorAll('.thumbnail').forEach((thumb) => thumb.classList.remove('active'));
-      button.classList.add('active');
-    });
-    modalThumbnails.appendChild(button);
-  });
-}
-
-function updateModalOptions(container, options, active, onSelect) {
-  container.innerHTML = '';
-  if (!options || options.length === 0) {
-    container.textContent = 'No options';
+  if (!els.cartBody || !els.cartTotal || !els.cartClear) {
     return;
   }
 
-  options.forEach((option) => {
-    const label = typeof option === 'string' ? option : option.name;
-    const chip = document.createElement('button');
-    chip.type = 'button';
-    chip.className = `chip${label === active ? ' active' : ''}`;
-    chip.textContent = label;
-    if (typeof option === 'object' && option.value) {
-      chip.style.setProperty('--chip-color', option.value);
-    }
-    chip.addEventListener('click', () => {
-      container.querySelectorAll('.chip').forEach((element) => element.classList.remove('active'));
-      chip.classList.add('active');
-      onSelect(label);
+  const summary = state.cart;
+  if (!summary || !Array.isArray(summary.items) || summary.items.length === 0) {
+    els.cartBody.innerHTML = '<p class="empty">Your cart is currently empty.</p>';
+    els.cartTotal.textContent = formatCurrency(0);
+    els.cartClear.disabled = true;
+  } else {
+    const lines = summary.items.map(item => {
+      const product = item.product || {};
+      const quantity = Number(item.quantity) || 0;
+      const productId = product.id || '';
+      const currency = product.currency || '$';
+      const price = product.formatted_price || formatCurrency(product.price, currency);
+      const lineTotal = item.formatted_line_total || formatCurrency(item.line_total, currency);
+      const image = Array.isArray(product.images) && product.images.length > 0 ? product.images[0] : 'https://picsum.photos/seed/ricktorious-default/200/200';
+
+      return `
+        <article class="cart-line" data-product="${escapeHtml(productId)}">
+          <div class="cart-media" style="background-image: url('${escapeHtml(image)}');"></div>
+          <div class="cart-info">
+            <h3>${escapeHtml(product.name || 'Product')}</h3>
+            <p class="muted">${escapeHtml(product.description || '')}</p>
+            <p class="price">${escapeHtml(price)}</p>
+          </div>
+          <div class="cart-controls">
+            <label>
+              <span class="sr-only">Quantity</span>
+              <input type="number" class="cart-quantity" min="0" value="${quantity}" data-product="${escapeHtml(productId)}">
+            </label>
+            <span class="line-total">${escapeHtml(lineTotal)}</span>
+            <button type="button" class="icon-button cart-remove" data-product="${escapeHtml(productId)}" aria-label="Remove ${escapeHtml(product.name || 'product')} from cart">&times;</button>
+          </div>
+        </article>
+      `;
+    }).join('');
+
+    els.cartBody.innerHTML = lines;
+    els.cartTotal.textContent = summary.formatted_total || formatCurrency(summary.total || 0);
+    els.cartClear.disabled = false;
+
+    els.cartBody.querySelectorAll('.cart-quantity').forEach(input => {
+      input.addEventListener('change', async (event) => {
+        const target = event.currentTarget;
+        const productId = target.dataset.product;
+        const quantity = Math.max(0, Number(target.value) || 0);
+        if (!productId) {
+          return;
+        }
+
+        target.disabled = true;
+        try {
+          await updateCart([{ product: productId, quantity }]);
+          showToast('Cart updated');
+        } catch (error) {
+          showToast(error.message, 'error');
+        } finally {
+          target.disabled = false;
+        }
+      });
     });
-    container.appendChild(chip);
-  });
+
+    els.cartBody.querySelectorAll('.cart-remove').forEach(button => {
+      button.addEventListener('click', async (event) => {
+        const productId = event.currentTarget.dataset.product;
+        if (!productId) {
+          return;
+        }
+
+        try {
+          await removeFromCart(productId);
+          showToast('Item removed');
+        } catch (error) {
+          showToast(error.message, 'error');
+        }
+      });
+    });
+  }
+
+  const count = summary && Number.isFinite(summary.item_count) ? summary.item_count : 0;
+  if (els.cartCount) {
+    els.cartCount.textContent = String(count);
+  }
 }
 
-modalAdd?.addEventListener('click', () => {
-  const product = products.find((item) => item.id === modalState.productId);
-  if (!product) return;
-  addToCart(product, {
-    color: modalState.color ?? product.colors[0]?.name ?? 'Default',
-    size: modalState.size ?? product.sizes[0] ?? 'One size'
+async function addToCart(productId) {
+  const data = await request(endpoints.cartAdd, {
+    method: 'POST',
+    body: {
+      product: productId,
+      quantity: 1
+    }
   });
-  closeModal();
-  openCart();
-});
 
-[modalClose, modalBackdrop].forEach((element) => {
-  element?.addEventListener('click', () => closeModal());
-});
-
-window.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape') {
-    closeModal();
-    closeCart();
-    closeSearch();
+  if (data && data.summary) {
+    state.cart = data.summary;
   }
-});
+  await refreshCart();
+  await refreshInsights();
+}
 
-themeToggle?.addEventListener('click', () => toggleTheme());
+async function updateCart(items) {
+  const summary = await request(endpoints.cartUpdate, {
+    method: 'POST',
+    body: { items }
+  });
+  state.cart = summary || state.cart;
+  renderCart();
+  await refreshInsights();
+}
 
-loadPersistedState();
-renderCart();
-renderProducts();
-setupFilters();
-setupCart();
-setupSearchPanel();
-setupMobileNav();
-setupNewsletter();
+async function removeFromCart(productId) {
+  const summary = await request(endpoints.cartRemove, {
+    method: 'POST',
+    body: { product: productId }
+  });
+  state.cart = summary || state.cart;
+  renderCart();
+  await refreshInsights();
+}
 
-const ceiling = Number(priceRange?.max ?? 600);
-priceValue.textContent = `Up to ${formatPrice(ceiling)}+`;
+async function clearCart() {
+  const summary = await request(endpoints.cartClear, { method: 'POST' });
+  state.cart = summary || state.cart;
+  renderCart();
+  await refreshInsights();
+}
 
+async function refreshCart() {
+  const summary = await request(endpoints.cartSummary);
+  if (summary) {
+    state.cart = summary;
+  }
+  renderCart();
+}
+
+function toggleCart(open) {
+  if (!els.cartOverlay) {
+    return;
+  }
+
+  if (open) {
+    els.cartOverlay.classList.add('open');
+    els.cartOverlay.setAttribute('aria-hidden', 'false');
+    if (els.cartButton) {
+      els.cartButton.setAttribute('aria-expanded', 'true');
+    }
+  } else {
+    els.cartOverlay.classList.remove('open');
+    els.cartOverlay.setAttribute('aria-hidden', 'true');
+    if (els.cartButton) {
+      els.cartButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+}
+
+function bindCartControls() {
+  if (els.cartButton) {
+    els.cartButton.addEventListener('click', () => {
+      toggleCart(!els.cartOverlay?.classList.contains('open'));
+    });
+  }
+
+  if (els.cartClose) {
+    els.cartClose.addEventListener('click', () => toggleCart(false));
+  }
+
+  if (els.cartOverlay) {
+    els.cartOverlay.addEventListener('click', (event) => {
+      if (event.target === els.cartOverlay) {
+        toggleCart(false);
+      }
+    });
+  }
+
+  if (els.cartClear) {
+    els.cartClear.addEventListener('click', async () => {
+      try {
+        await clearCart();
+        showToast('Cart cleared');
+      } catch (error) {
+        showToast(error.message, 'error');
+      }
+    });
+  }
+
+  if (els.cartCheckout) {
+    els.cartCheckout.addEventListener('click', () => toggleCart(false));
+  }
+}
+
+function bindFilters() {
+  if (els.searchInput) {
+    els.searchInput.addEventListener('input', (event) => {
+      state.filters.search = event.currentTarget.value || '';
+      renderProducts();
+    });
+  }
+
+  if (els.tagFilter) {
+    els.tagFilter.addEventListener('change', (event) => {
+      state.filters.tag = event.currentTarget.value || 'all';
+      renderProducts();
+    });
+  }
+
+  if (els.resetFilters) {
+    els.resetFilters.addEventListener('click', () => {
+      state.filters.search = '';
+      state.filters.tag = 'all';
+      if (els.searchInput) {
+        els.searchInput.value = '';
+      }
+      if (els.tagFilter) {
+        els.tagFilter.value = 'all';
+      }
+      renderProducts();
+    });
+  }
+}
+
+async function submitCheckout(event) {
+  event.preventDefault();
+  if (!els.checkoutForm) {
+    return;
+  }
+
+  const formData = new FormData(els.checkoutForm);
+  const payload = {
+    name: formData.get('name') || '',
+    email: formData.get('email') || '',
+    address: formData.get('address') || ''
+  };
+
+  try {
+    const order = await request(endpoints.checkout, {
+      method: 'POST',
+      body: payload
+    });
+
+    if (els.checkoutMessages) {
+      els.checkoutMessages.innerHTML = `<div class="message success">Order <strong>${escapeHtml(order.id || '')}</strong> confirmed. We have emailed ${escapeHtml(order.customer?.email || payload.email)}.</div>`;
+      els.checkoutMessages.hidden = false;
+    }
+
+    els.checkoutForm.reset();
+    await refreshCart();
+    await refreshInsights();
+    showToast('Checkout complete');
+  } catch (error) {
+    if (els.checkoutMessages) {
+      els.checkoutMessages.innerHTML = `<div class="message error">${escapeHtml(error.message)}</div>`;
+      els.checkoutMessages.hidden = false;
+    }
+    showToast(error.message, 'error');
+  }
+}
+
+async function fetchProducts() {
+  try {
+    const data = await request(endpoints.products);
+    state.products = Array.isArray(data?.products) ? data.products : [];
+    updateTagFilterOptions();
+    renderProducts();
+    await recordEvent('catalog.view', {
+      block: 'storefront.catalog',
+      total_products: state.products.length
+    });
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function refreshInsights() {
+  try {
+    const data = await request(endpoints.insights);
+    if (els.insightEvents) {
+      els.insightEvents.textContent = String(data?.total_events ?? 0);
+    }
+
+    if (els.insightBlocks) {
+      const popularity = data?.block_popularity || {};
+      const entries = Object.entries(popularity);
+      if (entries.length === 0) {
+        els.insightBlocks.innerHTML = '<li class="muted">Interact with the storefront to surface block insights.</li>';
+      } else {
+        els.insightBlocks.innerHTML = entries
+          .map(([block, count]) => `<li><span class="pill">${escapeHtml(block)}</span> ${Number(count)} events</li>`)
+          .join('');
+      }
+    }
+  } catch (error) {
+    showToast(error.message, 'error');
+  }
+}
+
+async function recordEvent(eventName, payload = {}) {
+  try {
+    await request(endpoints.analytics, {
+      method: 'POST',
+      body: {
+        event: eventName,
+        payload
+      }
+    });
+  } catch (error) {
+    // Silent fail to avoid interrupting UX
+  }
+}
+
+async function init() {
+  bindCartControls();
+  bindFilters();
+
+  if (els.checkoutForm) {
+    els.checkoutForm.addEventListener('submit', submitCheckout);
+  }
+
+  await Promise.all([
+    fetchProducts(),
+    refreshCart(),
+    refreshInsights(),
+    recordEvent('page.view', {
+      block: 'storefront.home',
+      path: window.location.pathname + window.location.hash
+    })
+  ]);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/web/assets/styles.css
+++ b/web/assets/styles.css
@@ -1,41 +1,20 @@
 :root {
-    color-scheme: light;
-    --bg: #f4f6fb;
-    --bg-alt: #ffffff;
-    --surface: #ffffff;
-    --surface-elevated: rgba(255, 255, 255, 0.85);
-    --border: rgba(16, 24, 40, 0.08);
-    --text: #1f2937;
-    --text-muted: #6b7280;
-    --accent: #2563eb;
-    --accent-strong: #1d4ed8;
-    --accent-soft: rgba(37, 99, 235, 0.08);
-    --accent-gradient: linear-gradient(135deg, #60a5fa 0%, #2563eb 50%, #7c3aed 100%);
-    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
-    --shadow-md: 0 12px 30px rgba(15, 23, 42, 0.12);
-    --shadow-lg: 0 30px 60px rgba(15, 23, 42, 0.16);
-    --radius-sm: 10px;
+    color-scheme: light dark;
+    --bg: radial-gradient(circle at top, rgba(56, 189, 248, 0.2), rgba(15, 23, 42, 0.95));
+    --surface: rgba(15, 23, 42, 0.85);
+    --surface-alt: rgba(15, 23, 42, 0.7);
+    --surface-light: rgba(226, 232, 240, 0.08);
+    --border: rgba(148, 163, 184, 0.25);
+    --text: #e2e8f0;
+    --text-muted: rgba(226, 232, 240, 0.7);
+    --accent: #38bdf8;
+    --accent-strong: #818cf8;
+    --success: #4ade80;
+    --error: #f87171;
+    --shadow: 0 28px 40px rgba(8, 47, 73, 0.45);
     --radius-md: 18px;
-    --radius-lg: 28px;
+    --radius-lg: 26px;
     --transition: 180ms ease;
-}
-
-body.dark {
-    color-scheme: dark;
-    --bg: #0b1120;
-    --bg-alt: #111827;
-    --surface: rgba(17, 24, 39, 0.88);
-    --surface-elevated: rgba(17, 24, 39, 0.94);
-    --border: rgba(255, 255, 255, 0.05);
-    --text: #f9fafb;
-    --text-muted: #9ca3af;
-    --accent: #8b5cf6;
-    --accent-strong: #7c3aed;
-    --accent-soft: rgba(139, 92, 246, 0.12);
-    --accent-gradient: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
-    --shadow-md: 0 12px 30px rgba(0, 0, 0, 0.45);
-    --shadow-lg: 0 40px 70px rgba(0, 0, 0, 0.55);
 }
 
 * {
@@ -44,12 +23,11 @@ body.dark {
 
 body {
     margin: 0;
+    min-height: 100vh;
     background: var(--bg);
     color: var(--text);
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     line-height: 1.6;
-    min-height: 100vh;
-    position: relative;
 }
 
 a {
@@ -62,997 +40,544 @@ a:focus {
     color: var(--accent);
 }
 
-.page {
-    max-width: 1200px;
+.shell {
+    width: min(1120px, 100%);
     margin: 0 auto;
-    padding: 0 1.5rem 6rem;
+    padding: 0 1.5rem;
 }
 
-.top-bar {
+.site-header {
     position: sticky;
-    top: 1.5rem;
+    top: 0;
     z-index: 40;
+    backdrop-filter: blur(18px);
+    background: rgba(15, 23, 42, 0.85);
+    border-bottom: 1px solid var(--border);
+}
+
+.header-shell {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: 1.5rem 0 2.5rem;
-    padding: 0.85rem 1.25rem;
-    background: var(--surface-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-sm);
-    backdrop-filter: blur(18px);
+    gap: 1.5rem;
+    padding: 1.25rem 1.5rem;
 }
 
 .brand {
     font-size: 1.35rem;
     font-weight: 700;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.05em;
 }
 
-.main-nav {
+.primary-nav {
     display: flex;
-    gap: 1.25rem;
+    gap: 1.2rem;
     font-weight: 500;
 }
 
-.main-nav a {
+.primary-nav a {
     padding: 0.35rem 0.6rem;
-    border-radius: var(--radius-sm);
+    border-radius: 999px;
     transition: background var(--transition), color var(--transition);
 }
 
-.main-nav a:hover,
-.main-nav a:focus {
-    background: var(--accent-soft);
+.primary-nav a:hover,
+.primary-nav a:focus {
+    background: var(--surface-light);
     color: var(--accent);
 }
 
-.top-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-}
-
-.icon-button {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    width: 42px;
-    height: 42px;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text);
-    position: relative;
-    transition: background var(--transition), transform var(--transition);
-}
-
-.icon-button:hover,
-.icon-button:focus {
-    background: var(--accent-soft);
-    transform: translateY(-1px);
-}
-
-.icon-button:focus-visible {
-    outline: 3px solid var(--accent);
-    outline-offset: 2px;
-}
-
-.icon {
-    width: 22px;
-    height: 22px;
-    display: inline-block;
-    mask-size: contain;
-    mask-repeat: no-repeat;
-    mask-position: center;
-    background-color: currentColor;
-}
-
-.icon-search { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35m0 0a7.5 7.5 0 1 0-10.607-10.607 7.5 7.5 0 0 0 10.607 10.607Z"/%3E%3C/svg%3E'); }
-.icon-cart { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437m0 0 1.35 5.062m-.002-.007h11.178a1.125 1.125 0 0 0 1.089-.858l1.194-4.782A.563.563 0 0 0 19.45 4.5H5.106m0 0L4.5 2.25M7.5 21a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm9 0a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"/%3E%3C/svg%3E'); }
-.icon-sun { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M12 3v1.5m0 15V21m9-9h-1.5m-15 0H3m15.364 6.364-1.06-1.06M7.696 7.696l-1.06-1.06m0 10.607 1.06-1.06m10.608-10.607-1.06 1.06M16.5 12a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z"/%3E%3C/svg%3E'); }
-.icon-moon { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 0 1 11.21 3 7.5 7.5 0 1 0 21 12.79Z"/%3E%3C/svg%3E'); }
-.icon-menu { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M3.75 6h16.5M3.75 12h16.5m-16.5 6h16.5"/%3E%3C/svg%3E'); }
-.icon-close { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/%3E%3C/svg%3E'); }
-.icon-delivery { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h11.25V9H21l-2.25 4.5h-4.5m-3 0H3V4.5Zm0 0V18m0 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm7.5 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Z"/%3E%3C/svg%3E'); }
-.icon-shield { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M13.5 21.621c-.433.246-.926.379-1.427.379s-.994-.133-1.427-.379l-1.098-.623a8.963 8.963 0 0 1-4.548-7.842V5.382c0-.527.214-1.032.594-1.402a1.98 1.98 0 0 1 1.409-.58c3.51-.05 5.548-.62 6.97-1.43a1.91 1.91 0 0 1 1.963 0c1.422.81 3.46 1.379 6.97 1.43a1.98 1.98 0 0 1 1.409.58c.38.37.594.875.594 1.402v7.774a8.963 8.963 0 0 1-4.548 7.842l-1.101.623Z"/%3E%3C/svg%3E'); }
-.icon-support { mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23000"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M16.5 4.5V3a1.5 1.5 0 0 0-3 0v1.5m3 0a3 3 0 0 1 3 3V12a5.25 5.25 0 0 1-5.25 5.25H12m4.5-12.75H9.75A3.75 3.75 0 0 0 6 7.5V12a5.25 5.25 0 0 0 5.25 5.25H12m0 0v3.75m0 0h3.75M12 21h-3.75"/%3E%3C/svg%3E'); }
-
-.mobile-menu {
-    display: none;
-}
-
-.cart-count {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    font-size: 0.75rem;
-    background: var(--accent);
-    color: #fff;
-    min-width: 20px;
-    height: 20px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 999px;
-    padding: 0 6px;
-    font-weight: 600;
-}
-
-.search-panel {
-    position: fixed;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.45);
-    display: none;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 6rem 1.5rem 1.5rem;
-    z-index: 50;
-}
-
-.search-panel.active {
-    display: flex;
-}
-
-.search-content {
-    width: min(640px, 100%);
-    background: var(--surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-lg);
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem 1.25rem;
-}
-
-.search-content input {
-    flex: 1 1 auto;
-    border: none;
-    font-size: 1rem;
-    background: transparent;
-    color: var(--text);
-}
-
-.search-content input:focus {
-    outline: none;
-}
-
-.hero {
-    margin-bottom: 3.5rem;
-    display: grid;
-    gap: 2.5rem;
-    grid-template-columns: repeat(12, 1fr);
-    padding: 2.75rem;
-    background: var(--surface);
-    border-radius: calc(var(--radius-lg) + 6px);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-md);
-}
-
-.hero-content {
-    grid-column: span 6;
-}
-
-.hero-content h1 {
-    font-size: clamp(2.5rem, 3vw + 1rem, 3.4rem);
-    line-height: 1.05;
-    margin-bottom: 1rem;
-}
-
-.hero-content .lead {
-    color: var(--text-muted);
-    max-width: 32rem;
-    margin-bottom: 1.75rem;
-}
-
-.hero-actions {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 2rem;
-}
-
-.hero-stats {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.25rem;
-    margin: 0;
-}
-
-.hero-stats div {
-    padding: 1rem;
-    border-radius: var(--radius-md);
-    background: var(--accent-soft);
-}
-
-.hero-stats dt {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--text-muted);
-}
-
-.hero-stats dd {
-    margin: 0.35rem 0 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-}
-
-.hero-showcase {
-    grid-column: span 6;
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
-}
-
-.showcase-card {
-    position: relative;
-    padding: 1.5rem;
-    border-radius: var(--radius-md);
-    color: #fff;
-    min-height: 180px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    overflow: hidden;
-}
-
-.showcase-card::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.4), transparent);
-    opacity: 0;
-    transition: opacity var(--transition);
-}
-
-.showcase-card:hover::after {
-    opacity: 1;
-}
-
-.showcase-card h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1.1rem;
-}
-
-.showcase-card p {
-    margin: 0;
-    font-size: 0.95rem;
-    line-height: 1.5;
-}
-
-.showcase-card.footwear { background: linear-gradient(140deg, #0f172a, #2563eb); }
-.showcase-card.apparel { background: linear-gradient(140deg, #111827, #9333ea); }
-.showcase-card.smart-home { background: linear-gradient(140deg, #0b1120, #14b8a6); }
-
-.filters {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-}
-
-.filter-tabs {
-    display: inline-flex;
-    padding: 0.35rem;
-    border-radius: var(--radius-lg);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-sm);
-}
-
-.tab-button {
-    border: none;
-    background: transparent;
-    padding: 0.65rem 1.25rem;
-    border-radius: var(--radius-md);
-    font-weight: 500;
-    cursor: pointer;
-    color: var(--text-muted);
-    transition: background var(--transition), color var(--transition), transform var(--transition);
-}
-
-.tab-button.active {
-    background: var(--accent-gradient);
-    color: #fff;
-    box-shadow: var(--shadow-sm);
-}
-
-.tab-button:not(.active):hover {
-    background: rgba(148, 163, 184, 0.12);
-    color: var(--text);
-}
-
-.filter-controls {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-}
-
-.control {
+.header-actions {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.6rem 0.9rem;
-    background: var(--surface);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-sm);
-}
-
-.control select,
-.control input[type="search"],
-.control input[type="range"] {
-    border: none;
-    background: transparent;
-    color: var(--text);
-    font: inherit;
-}
-
-.control input[type="search"]:focus,
-.control select:focus {
-    outline: none;
-}
-
-.control-label {
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    color: var(--text-muted);
-}
-
-.search-control {
-    position: relative;
-    padding-right: 2.4rem;
-}
-
-.search-control .icon-search {
-    position: absolute;
-    right: 0.85rem;
-    opacity: 0.65;
-}
-
-#price-range {
-    width: 160px;
-}
-
-.range-value {
-    font-size: 0.85rem;
-    color: var(--text-muted);
 }
 
 .button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-weight: 600;
+    gap: 0.5rem;
+    padding: 0.75rem 1.4rem;
     border-radius: 999px;
-    padding: 0.75rem 1.75rem;
+    border: none;
+    font-weight: 600;
     cursor: pointer;
-    transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
 .button.primary {
-    background: var(--accent-gradient);
-    color: #fff;
-    box-shadow: 0 18px 30px rgba(37, 99, 235, 0.25);
-    border: none;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: #0f172a;
+    box-shadow: var(--shadow);
 }
 
-.button.primary:hover {
+.button.primary:hover,
+.button.primary:focus {
     transform: translateY(-1px);
-    box-shadow: 0 20px 40px rgba(37, 99, 235, 0.28);
 }
 
-.button.secondary {
-    border: 1px solid var(--border);
+.button.ghost {
     background: transparent;
     color: var(--text);
-}
-
-.button.secondary:hover {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
-}
-
-.product-grid {
-    position: relative;
-    margin-bottom: 4rem;
-}
-
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 1.75rem;
-}
-
-.product-card {
-    background: var(--surface);
-    border-radius: calc(var(--radius-md) + 4px);
     border: 1px solid var(--border);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    box-shadow: var(--shadow-sm);
-    transition: transform var(--transition), box-shadow var(--transition);
-    position: relative;
 }
 
-.product-card:hover {
-    transform: translateY(-6px);
-    box-shadow: var(--shadow-md);
-}
-
-.product-media {
-    position: relative;
-    padding-top: 70%;
-    overflow: hidden;
-}
-
-.product-media img {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 220ms ease;
-}
-
-.product-card:hover .product-media img {
-    transform: scale(1.05);
-}
-
-.product-badges {
-    position: absolute;
-    inset: 16px 16px auto auto;
-    display: flex;
-    gap: 0.35rem;
-    flex-wrap: wrap;
+.button.ghost:hover,
+.button.ghost:focus {
+    border-color: var(--accent);
+    color: var(--accent);
 }
 
 .badge {
-    background: rgba(17, 24, 39, 0.75);
-    color: #fff;
-    padding: 0.25rem 0.75rem;
+    background: var(--accent);
+    color: #0f172a;
     border-radius: 999px;
+    padding: 0.1rem 0.55rem;
     font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.hero {
+    padding: 4rem 0 3rem;
+}
+
+.hero-shell {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+}
+
+.hero-copy h1 {
+    font-size: clamp(2.5rem, 4vw, 3.25rem);
+    line-height: 1.1;
+    margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.8rem;
+    color: var(--accent);
+}
+
+.lead {
+    color: var(--text-muted);
+    max-width: 520px;
+}
+
+.hero-actions {
+    display: flex;
+    gap: 0.85rem;
+    margin: 1.75rem 0;
+}
+
+.metrics {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    margin: 2rem 0 0;
+}
+
+.metrics dt {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+}
+
+.metrics dd {
+    margin: 0.4rem 0 0;
     font-weight: 600;
-    letter-spacing: 0.04em;
+}
+
+.hero-media {
+    display: grid;
+    gap: 1rem;
+}
+
+.hero-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+    text-align: center;
+    font-weight: 600;
+}
+
+.section-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.section-header p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+    max-width: 520px;
+}
+
+.catalog {
+    padding: 3rem 0;
+}
+
+.catalog-controls {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.catalog-controls label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 500;
+}
+
+.catalog-controls input,
+.catalog-controls select {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: inherit;
+    padding: 0.65rem 0.9rem;
+    border-radius: var(--radius-md);
+    font: inherit;
+    min-width: 220px;
+}
+
+.product-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.product-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+}
+
+.product-media {
+    padding-top: 68%;
+    background-size: cover;
+    background-position: center;
 }
 
 .product-body {
-    padding: 1.35rem 1.5rem 1.25rem;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    padding: 1.5rem;
 }
 
-.product-body h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.product-body p {
-    margin: 0;
+.product-description {
     color: var(--text-muted);
-    font-size: 0.92rem;
-    min-height: 48px;
+    margin: 0;
 }
 
 .product-meta {
     display: flex;
-    align-items: center;
     justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 .price {
-    font-size: 1.15rem;
-    font-weight: 600;
+    color: var(--accent);
+    font-weight: 700;
 }
 
-.rating {
+.product-tags {
     display: flex;
-    align-items: center;
     gap: 0.35rem;
-    font-size: 0.85rem;
-    color: var(--text-muted);
-}
-
-.rating-stars {
-    display: inline-flex;
-    gap: 2px;
-}
-
-.rating-stars span {
-    width: 14px;
-    height: 14px;
-    background: linear-gradient(90deg, #facc15, #f59e0b);
-    mask: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="%23000" viewBox="0 0 20 20"%3E%3Cpath d="M9.049.927c.3-.921 1.603-.921 1.902 0l1.286 3.958a1 1 0 0 0 .95.69h4.162c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 0 0-.364 1.118l1.287 3.957c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 0 0-1.176 0l-3.37 2.45c-.785.57-1.84-.196-1.54-1.118l1.287-3.957a1 1 0 0 0-.364-1.118L.975 7.385c-.783-.57-.38-1.81.588-1.81h4.162a1 1 0 0 0 .95-.69L7.96.927Z"/%3E%3C/svg%3E') center / contain;
-}
-
-.card-footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-.card-footer button {
-    flex: 1 1 auto;
-}
-
-.quick-view {
-    font-weight: 600;
-    color: var(--accent);
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-}
-
-.quick-view:hover,
-.quick-view:focus {
-    text-decoration: underline;
-}
-
-.empty-state {
-    text-align: center;
-    padding: 3rem 1.5rem;
-    background: var(--surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-sm);
-}
-
-.empty-icon {
-    width: 72px;
-    height: 72px;
-    margin: 0 auto 1rem;
-    border-radius: 24px;
-    background: var(--accent-soft);
-}
-
-.collections {
-    display: grid;
-    gap: 2rem;
-    margin-bottom: 4rem;
-}
-
-.collection-card {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    gap: 2rem;
-    align-items: center;
-}
-
-.collection-card.reverse .collection-media {
-    order: 2;
-}
-
-.collection-card.reverse .collection-body {
-    order: 1;
-}
-
-.collection-media {
-    grid-column: span 5;
-    min-height: 260px;
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-md);
-    background-size: cover;
-    background-position: center;
-}
-
-.collection-lounge { background-image: url('https://images.unsplash.com/photo-1524386189627-88c8f1a43863?auto=format&fit=crop&w=900&q=80'); }
-.collection-commute { background-image: url('https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=900&q=80'); }
-
-.collection-body {
-    grid-column: span 7;
-    background: var(--surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    padding: 2rem;
-    box-shadow: var(--shadow-sm);
-}
-
-.collection-body h2 {
-    margin-top: 0.35rem;
-    font-size: 2rem;
-}
-
-.collection-body p {
-    color: var(--text-muted);
-}
-
-.link {
-    color: var(--accent);
-    font-weight: 600;
-}
-
-.highlights {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.75rem;
-    margin-bottom: 4rem;
-}
-
-.highlights article {
-    background: var(--surface);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    padding: 2rem;
-    box-shadow: var(--shadow-sm);
-}
-
-.highlights .icon {
-    width: 36px;
-    height: 36px;
-    margin-bottom: 1rem;
-    color: var(--accent);
-}
-
-.testimonials {
-    background: var(--surface);
-    border-radius: calc(var(--radius-lg) + 6px);
-    border: 1px solid var(--border);
-    padding: 3rem;
-    margin-bottom: 4rem;
-    box-shadow: var(--shadow-md);
-}
-
-.testimonials header {
-    text-align: center;
-    max-width: 640px;
-    margin: 0 auto 2.5rem;
-}
-
-.testimonial-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1.5rem;
-}
-
-.testimonial-grid article {
-    background: var(--bg-alt);
-    border-radius: var(--radius-md);
-    padding: 1.75rem;
-    border: 1px solid var(--border);
-}
-
-.testimonial-grid footer {
-    margin-top: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-}
-
-.newsletter {
-    margin-bottom: 4rem;
-}
-
-.newsletter-card {
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    border-radius: calc(var(--radius-lg) + 6px);
-    overflow: hidden;
-    border: 1px solid var(--border);
-    box-shadow: var(--shadow-md);
-    background: var(--surface);
-}
-
-.newsletter-body {
-    grid-column: span 7;
-    padding: 3rem;
-}
-
-.newsletter-media {
-    grid-column: span 5;
-    min-height: 320px;
-    background-image: url('https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80');
-    background-size: cover;
-    background-position: center;
-}
-
-.newsletter-form {
-    margin-top: 1.5rem;
-    display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
 }
 
-.newsletter-form input {
-    flex: 1 1 220px;
+.pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.65rem;
     border-radius: 999px;
+    background: rgba(56, 189, 248, 0.18);
+    font-size: 0.75rem;
+}
+
+.empty-state,
+.empty {
+    background: var(--surface-alt);
+    border-radius: var(--radius-lg);
     border: 1px solid var(--border);
-    padding: 0.75rem 1.25rem;
-    font: inherit;
-    background: var(--bg-alt);
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-muted);
+    margin-top: 2rem;
 }
 
-.newsletter-form input:focus {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-}
-
-.form-feedback {
-    width: 100%;
-    min-height: 1.25rem;
-    font-size: 0.9rem;
-}
-
-.footer {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 2rem;
+.insights {
     padding: 3rem 0;
-    border-top: 1px solid var(--border);
 }
 
-.footer h3 {
-    margin-top: 0;
+.insight-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.footer ul {
+.insight-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+}
+
+.metric {
+    font-size: 2.25rem;
+    font-weight: 700;
+    margin: 0.5rem 0 0.75rem;
+}
+
+.muted {
+    color: var(--text-muted);
+}
+
+.tag-list {
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
     gap: 0.5rem;
-    color: var(--text-muted);
 }
 
-.social-links a {
-    font-weight: 600;
+.tag-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.checkout {
+    padding: 3rem 0 4rem;
+}
+
+.checkout-form {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    background: var(--surface);
+    padding: 2rem;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+}
+
+.checkout-form label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 500;
+}
+
+.checkout-form label.full {
+    grid-column: 1 / -1;
+}
+
+.checkout-form input,
+.checkout-form textarea {
+    background: rgba(15, 23, 42, 0.9);
+    border: 1px solid var(--border);
+    color: inherit;
+    padding: 0.75rem 0.9rem;
+    border-radius: var(--radius-md);
+    font: inherit;
+}
+
+.checkout-form textarea {
+    resize: vertical;
+}
+
+.messages {
+    margin-bottom: 1.5rem;
+}
+
+.message {
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    margin-bottom: 0.75rem;
+}
+
+.message.success {
+    border-color: rgba(74, 222, 128, 0.45);
+    background: rgba(74, 222, 128, 0.15);
+    color: #bbf7d0;
+}
+
+.message.error {
+    border-color: rgba(248, 113, 113, 0.4);
+    background: rgba(248, 113, 113, 0.15);
+    color: #fecaca;
+}
+
+.cart-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(8, 15, 30, 0.65);
+    display: none;
+    align-items: stretch;
+    justify-content: flex-end;
+    z-index: 50;
+}
+
+.cart-overlay.open {
+    display: flex;
 }
 
 .cart-panel {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: min(400px, 100%);
-    height: 100vh;
-    background: var(--surface);
+    width: min(420px, 100%);
+    background: rgba(11, 18, 32, 0.98);
     border-left: 1px solid var(--border);
-    box-shadow: var(--shadow-lg);
-    transform: translateX(100%);
-    transition: transform 220ms ease;
     display: flex;
     flex-direction: column;
-    z-index: 60;
 }
 
-.cart-panel.active {
-    transform: translateX(0);
-}
-
-.cart-header,
-.cart-footer {
-    padding: 1.5rem;
+.cart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
     border-bottom: 1px solid var(--border);
+}
+
+.cart-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.cart-line {
+    display: grid;
+    grid-template-columns: 72px 1fr auto;
+    gap: 1rem;
+    align-items: start;
+    background: var(--surface-alt);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    padding: 0.75rem;
+}
+
+.cart-media {
+    width: 72px;
+    height: 72px;
+    border-radius: var(--radius-md);
+    background-size: cover;
+    background-position: center;
+}
+
+.cart-info h3 {
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
+}
+
+.cart-controls {
+    display: grid;
+    grid-auto-flow: row;
+    gap: 0.5rem;
+    justify-items: end;
+}
+
+.cart-quantity {
+    width: 72px;
+    padding: 0.4rem 0.6rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: rgba(15, 23, 42, 0.9);
+    color: inherit;
+    font: inherit;
+}
+
+.cart-remove {
+    background: transparent;
+    border: none;
+    color: rgba(248, 113, 113, 0.85);
+    font-size: 1.4rem;
+    cursor: pointer;
+}
+
+.cart-remove:hover,
+.cart-remove:focus {
+    color: var(--error);
 }
 
 .cart-footer {
     border-top: 1px solid var(--border);
-    border-bottom: none;
-}
-
-.cart-body {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    padding: 1.5rem;
-}
-
-.cart-items {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    padding: 1.25rem 1.5rem;
     display: grid;
     gap: 1rem;
 }
 
-.cart-item {
-    display: grid;
-    grid-template-columns: 80px 1fr;
-    gap: 1rem;
-    background: var(--bg-alt);
-    border-radius: var(--radius-md);
-    padding: 0.85rem;
-    border: 1px solid var(--border);
-}
-
-.cart-item img {
-    width: 100%;
-    height: 80px;
-    object-fit: cover;
-    border-radius: var(--radius-sm);
-}
-
-.cart-item h4 {
-    margin: 0;
-    font-size: 1rem;
-}
-
-.cart-meta {
+.cart-total {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    margin-top: 0.5rem;
+    align-items: baseline;
 }
 
-.quantity-control {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    padding: 0.25rem 0.6rem;
+.cart-total strong {
+    font-size: 1.35rem;
 }
 
-.quantity-control button {
-    border: none;
+.cart-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.icon-button {
     background: transparent;
+    border: none;
+    color: inherit;
     cursor: pointer;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 1.5rem;
 }
 
-.cart-empty {
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 2rem 0 3rem;
     text-align: center;
     color: var(--text-muted);
-    display: none;
 }
 
-.cart-panel.empty .cart-empty {
-    display: block;
-}
-
-.totals {
-    display: grid;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-}
-
-.cart-note {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    margin: 0;
-}
-
-.modal {
+.toast {
     position: fixed;
-    inset: 0;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 70;
-}
-
-.modal.active {
-    display: flex;
-}
-
-.modal-backdrop {
-    position: absolute;
-    inset: 0;
-    background: rgba(15, 23, 42, 0.55);
-}
-
-.modal-dialog {
-    position: relative;
-    z-index: 71;
-    background: var(--surface);
-    border-radius: calc(var(--radius-lg) + 6px);
+    bottom: 1.5rem;
+    right: 1.5rem;
+    background: rgba(15, 23, 42, 0.95);
     border: 1px solid var(--border);
-    box-shadow: var(--shadow-lg);
-    width: min(900px, calc(100% - 2rem));
-    max-height: calc(100vh - 3rem);
-    overflow: hidden;
-    display: grid;
-    grid-template-columns: repeat(12, 1fr);
-}
-
-.modal-gallery {
-    grid-column: span 6;
-    background: var(--bg-alt);
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.modal-gallery img {
-    width: 100%;
     border-radius: var(--radius-md);
-    object-fit: cover;
-}
-
-.thumbnail-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
-    gap: 0.75rem;
-}
-
-.thumbnail {
-    border: 2px solid transparent;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    overflow: hidden;
-}
-
-.thumbnail img {
-    width: 100%;
-    height: 70px;
-    object-fit: cover;
-}
-
-.thumbnail.active {
-    border-color: var(--accent);
-}
-
-.modal-body {
-    grid-column: span 6;
-    padding: 2.25rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-}
-
-.modal-price {
-    font-size: 1.5rem;
-    font-weight: 600;
-}
-
-.modal-options {
-    display: grid;
-    gap: 1.5rem;
-}
-
-.chip-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-}
-
-.chip {
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    padding: 0.4rem 0.95rem;
-    background: var(--bg-alt);
-    cursor: pointer;
+    padding: 0.9rem 1.2rem;
+    box-shadow: var(--shadow);
     font-weight: 500;
-    transition: background var(--transition), border var(--transition), color var(--transition);
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    --chip-color: transparent;
 }
 
-.chip.active,
-.chip:hover {
-    background: var(--accent-soft);
-    border-color: var(--accent);
-    color: var(--accent-strong);
-}
-
-.chip::before {
-    content: '';
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--chip-color);
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    display: inline-flex;
-}
-
-.modal-close {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    background: var(--bg-alt);
+.toast[data-tone="error"] {
+    border-color: rgba(248, 113, 113, 0.6);
+    color: #fecaca;
 }
 
 .sr-only {
@@ -1067,113 +592,26 @@ a:focus {
     border: 0;
 }
 
-@media (max-width: 1024px) {
-    .hero {
-        grid-template-columns: repeat(1, minmax(0, 1fr));
-    }
-
-    .hero-content,
-    .hero-showcase {
-        grid-column: span 1;
-    }
-
-    .hero-showcase {
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-
-    .collection-card,
-    .newsletter-card,
-    .modal-dialog {
-        grid-template-columns: repeat(1, minmax(0, 1fr));
-    }
-
-    .collection-media,
-    .collection-body,
-    .newsletter-body,
-    .newsletter-media,
-    .modal-gallery,
-    .modal-body {
-        grid-column: span 1;
-    }
-
-    .modal-dialog {
-        max-height: calc(100vh - 1.5rem);
-    }
-}
-
-@media (max-width: 860px) {
-    .main-nav {
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, 0.7);
-        backdrop-filter: blur(10px);
-        padding: 6rem 2rem 2rem;
-        flex-direction: column;
-        gap: 1.25rem;
-        transform: translateY(-100%);
-        transition: transform var(--transition);
-    }
-
-    .main-nav.open {
-        transform: translateY(0);
-    }
-
-    .main-nav a {
-        font-size: 1.15rem;
-    }
-
-    .mobile-menu {
-        display: inline-flex;
-    }
-
-    .filter-controls {
-        width: 100%;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-    }
-
-    .filter-controls .control {
-        flex: 1 1 220px;
-    }
-
-    .footer {
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-}
-
-@media (max-width: 640px) {
-    .page {
-        padding: 0 1rem 4rem;
-    }
-
-    .top-bar {
-        padding: 0.75rem 1rem;
-    }
-
-    .hero {
-        padding: 2rem 1.5rem;
+@media (max-width: 720px) {
+    .primary-nav {
+        display: none;
     }
 
     .hero-actions {
         flex-direction: column;
-        align-items: stretch;
+        align-items: flex-start;
     }
 
-    .filter-tabs {
-        width: 100%;
-        flex-wrap: wrap;
-        gap: 0.5rem;
+    .cart-line {
+        grid-template-columns: 1fr;
     }
 
-    .filter-tabs .tab-button {
-        flex: 1 1 calc(50% - 0.5rem);
+    .cart-controls {
+        justify-items: stretch;
+        grid-auto-flow: column;
     }
 
-    .grid {
-        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    }
-
-    .newsletter-form {
+    .cart-actions {
         flex-direction: column;
     }
 }

--- a/web/ricktorious.php
+++ b/web/ricktorious.php
@@ -93,8 +93,14 @@ $app = new Application(
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 $uri = $_SERVER['REQUEST_URI'] ?? '/';
 $path = parse_url($uri, PHP_URL_PATH) ?: '/';
-if ($path === '/ricktorious.php') {
+$scriptPath = '/ricktorious.php';
+if ($path === $scriptPath) {
     $path = '/';
+} elseif (str_starts_with($path, $scriptPath . '/')) {
+    $path = substr($path, strlen($scriptPath));
+    if ($path === '') {
+        $path = '/';
+    }
 }
 if (str_starts_with($path, '/api/')) {
     $payload = $_POST;

--- a/web/storefront.php
+++ b/web/storefront.php
@@ -1,319 +1,183 @@
 <?php
+declare(strict_types=1);
+
+session_start();
+
 $assetVersion = (string) (file_exists(__DIR__ . '/assets/styles.css') ? filemtime(__DIR__ . '/assets/styles.css') : time());
 ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nova Market &mdash; Modern Lifestyle Store</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ricktorious Limited — Adaptive Commerce Experience</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/web/assets/styles.css?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>">
 </head>
 <body>
-    <div class="page">
-        <header class="top-bar">
-            <div class="brand">Nova Market</div>
-            <nav class="main-nav" aria-label="Primary">
-                <a href="#collections">Collections</a>
-                <a href="#products">Products</a>
-                <a href="#stories">Stories</a>
-                <a href="#newsletter">Subscribe</a>
-            </nav>
-            <div class="top-actions">
-                <button class="icon-button" id="search-toggle" aria-label="Open search" aria-expanded="false">
-                    <span class="icon icon-search"></span>
-                </button>
-                <button class="icon-button" id="cart-toggle" aria-label="Open shopping cart" aria-expanded="false">
-                    <span class="icon icon-cart"></span>
-                    <span class="cart-count" id="cart-count">0</span>
-                </button>
-                <button class="icon-button" id="theme-toggle" aria-label="Toggle theme">
-                    <span class="icon icon-sun"></span>
-                </button>
-                <button class="icon-button mobile-menu" id="mobile-menu" aria-label="Toggle menu" aria-expanded="false">
-                    <span class="icon icon-menu"></span>
-                </button>
-            </div>
-        </header>
+<header class="site-header">
+    <div class="shell header-shell">
+        <div class="brand">Ricktorious Limited</div>
+        <nav class="primary-nav" aria-label="Primary">
+            <a href="#home">Home</a>
+            <a href="#catalog">Catalog</a>
+            <a href="#insights">Insights</a>
+            <a href="#checkout">Checkout</a>
+        </nav>
+        <div class="header-actions">
+            <button type="button" class="button ghost" id="cart-button" aria-expanded="false">
+                Cart <span class="badge" id="cart-count">0</span>
+            </button>
+        </div>
+    </div>
+</header>
 
-        <div class="search-panel" id="search-panel" role="dialog" aria-modal="true" aria-hidden="true">
-            <div class="search-content">
-                <label for="global-search" class="sr-only">Search for products</label>
-                <input id="global-search" type="search" placeholder="Search for anything from sneakers to smart homes..." autocomplete="off">
-                <button class="icon-button" id="search-close" aria-label="Close search">
-                    <span class="icon icon-close"></span>
-                </button>
+<main>
+    <section class="hero" id="home">
+        <div class="shell hero-shell">
+            <div class="hero-copy">
+                <p class="eyebrow">Ricktorious Commerce Lab</p>
+                <h1>Launch an AI-personalised storefront in minutes.</h1>
+                <p class="lead">The Ricktorious Limited experience blends adaptive merchandising, behavioural telemetry, and extension-ready APIs so you can pilot new retail ideas without reinventing the platform.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="#catalog">Browse products</a>
+                    <a class="button ghost" href="#insights">View insights</a>
+                </div>
+                <dl class="metrics">
+                    <div>
+                        <dt>Realtime cart engine</dt>
+                        <dd>Session aware &amp; API driven</dd>
+                    </div>
+                    <div>
+                        <dt>Operational tooling</dt>
+                        <dd>CRM, POS &amp; fulfilment APIs</dd>
+                    </div>
+                    <div>
+                        <dt>Personalisation</dt>
+                        <dd>Behavioural insights per visitor</dd>
+                    </div>
+                </dl>
+            </div>
+            <div class="hero-media" aria-hidden="true">
+                <div class="hero-card">Personalised drops</div>
+                <div class="hero-card">Commerce extensions</div>
+                <div class="hero-card">Fulfilment orchestration</div>
             </div>
         </div>
+    </section>
 
-        <main>
-            <section class="hero" id="collections">
-                <div class="hero-content">
-                    <p class="eyebrow">SS24 Capsule</p>
-                    <h1>Design-led essentials crafted for modern living.</h1>
-                    <p class="lead">Shop limited-run drops from emerging designers, sustainable staples from world-class brands, and smart tech that elevates every space.</p>
-                    <div class="hero-actions">
-                        <a class="button primary" href="#products">Shop the collection</a>
-                        <a class="button secondary" href="#stories">Explore stories</a>
-                    </div>
-                    <dl class="hero-stats">
-                        <div>
-                            <dt>Premium labels</dt>
-                            <dd>150+</dd>
-                        </div>
-                        <div>
-                            <dt>Community reviews</dt>
-                            <dd>12k+</dd>
-                        </div>
-                        <div>
-                            <dt>Planet positive</dt>
-                            <dd>82% sustainable</dd>
-                        </div>
-                    </dl>
+    <section class="catalog" id="catalog">
+        <div class="shell catalog-shell">
+            <header class="section-header">
+                <div>
+                    <h2>Catalog</h2>
+                    <p>Products are sourced from the Ricktorious content engine and delivered through the headless commerce API.</p>
                 </div>
-                <div class="hero-showcase">
-                    <div class="showcase-card footwear">
-                        <h3>Footwear</h3>
-                        <p>Future-proof sneakers engineered for daily performance.</p>
-                    </div>
-                    <div class="showcase-card apparel">
-                        <h3>Apparel</h3>
-                        <p>Modular layers built with recycled technical fabrics.</p>
-                    </div>
-                    <div class="showcase-card smart-home">
-                        <h3>Smart Living</h3>
-                        <p>Connected devices that adapt to your routines.</p>
-                    </div>
-                </div>
-            </section>
-
-            <section class="filters" aria-label="Product filters">
-                <div class="filter-tabs" role="tablist">
-                    <button class="tab-button active" data-category="all" role="tab" aria-selected="true">All</button>
-                    <button class="tab-button" data-category="footwear" role="tab" aria-selected="false">Footwear</button>
-                    <button class="tab-button" data-category="apparel" role="tab" aria-selected="false">Apparel</button>
-                    <button class="tab-button" data-category="accessories" role="tab" aria-selected="false">Accessories</button>
-                    <button class="tab-button" data-category="smart-living" role="tab" aria-selected="false">Smart living</button>
-                </div>
-                <div class="filter-controls">
-                    <label class="control search-control">
-                        <span class="sr-only">Search products</span>
-                        <input type="search" id="inline-search" placeholder="Search products" autocomplete="off">
-                        <span class="icon icon-search"></span>
+                <div class="catalog-controls">
+                    <label>
+                        <span class="control-label">Search</span>
+                        <input type="search" id="search-input" placeholder="Search products">
                     </label>
-                    <label class="control">
-                        <span class="control-label">Sort</span>
-                        <select id="sort-select">
-                            <option value="featured">Featured</option>
-                            <option value="newest">Newest</option>
-                            <option value="price-asc">Price: Low to High</option>
-                            <option value="price-desc">Price: High to Low</option>
-                            <option value="rating">Top Rated</option>
+                    <label>
+                        <span class="control-label">Category</span>
+                        <select id="tag-filter">
+                            <option value="all">All categories</option>
                         </select>
                     </label>
-                    <label class="control">
-                        <span class="control-label">Price</span>
-                        <input type="range" id="price-range" min="80" max="600" value="600">
-                        <span class="range-value" id="price-value">Up to $600+</span>
-                    </label>
                 </div>
-            </section>
-
-            <section class="product-grid" id="products" aria-live="polite">
-                <div class="grid" id="product-grid"></div>
-                <div class="empty-state" id="empty-state" hidden>
-                    <div class="empty-icon"></div>
-                    <h2>No products found</h2>
-                    <p>Try adjusting the filters or explore another category.</p>
-                    <button class="button secondary" id="reset-filters">Reset filters</button>
-                </div>
-            </section>
-
-            <section class="collections" id="stories">
-                <article class="collection-card">
-                    <div class="collection-media collection-lounge"></div>
-                    <div class="collection-body">
-                        <p class="eyebrow">Editorial</p>
-                        <h2>The lounge remix</h2>
-                        <p>Slow down in reimagined loungewear sets and adaptive lighting that transforms any living room into a sanctuary.</p>
-                        <a href="#" class="link">Read the story</a>
-                    </div>
-                </article>
-                <article class="collection-card reverse">
-                    <div class="collection-media collection-commute"></div>
-                    <div class="collection-body">
-                        <p class="eyebrow">Spotlight</p>
-                        <h2>City commute essentials</h2>
-                        <p>Weatherproof jackets, antimicrobial knits, and the smartest carry solutions engineered to move with you.</p>
-                        <a href="#" class="link">Explore the curation</a>
-                    </div>
-                </article>
-            </section>
-
-            <section class="highlights" aria-label="Store highlights">
-                <article>
-                    <span class="icon icon-delivery"></span>
-                    <h3>Carbon-neutral delivery</h3>
-                    <p>Fast worldwide shipping with offset emissions and recyclable packaging by default.</p>
-                </article>
-                <article>
-                    <span class="icon icon-shield"></span>
-                    <h3>Secure payments</h3>
-                    <p>Checkout with Apple Pay, Google Pay, major cards, and split payments with 3D Secure.</p>
-                </article>
-                <article>
-                    <span class="icon icon-support"></span>
-                    <h3>Concierge support</h3>
-                    <p>Dedicated stylists and product specialists ready to assist 7 days a week.</p>
-                </article>
-            </section>
-
-            <section class="testimonials">
-                <header>
-                    <h2>Loved by creators &amp; founders</h2>
-                    <p>Our community shares how Nova Market elevates their routines.</p>
-                </header>
-                <div class="testimonial-grid">
-                    <article>
-                        <p>“Everything feels curated with intention. The product detail pages are like having a stylist and engineer co-sign every purchase.”</p>
-                        <footer>
-                            <strong>Jamie Patel</strong>
-                            <span>Founder, Studio Eleven</span>
-                        </footer>
-                    </article>
-                    <article>
-                        <p>“Nova’s smart home lineup is the only place I’ve found devices that blend into my space while working flawlessly together.”</p>
-                        <footer>
-                            <strong>Maya Cortez</strong>
-                            <span>Architect &amp; content creator</span>
-                        </footer>
-                    </article>
-                    <article>
-                        <p>“From responsive support to sustainable sourcing, Nova Market sets the benchmark for modern retail.”</p>
-                        <footer>
-                            <strong>Luke Anders</strong>
-                            <span>Creative Director</span>
-                        </footer>
-                    </article>
-                </div>
-            </section>
-
-            <section class="newsletter" id="newsletter">
-                <div class="newsletter-card">
-                    <div class="newsletter-body">
-                        <p class="eyebrow">Stay in the loop</p>
-                        <h2>Access private drops, invites, and insider pricing.</h2>
-                        <p>Subscribe to be the first to shop limited collaborations and receive insights from our design partners.</p>
-                        <form class="newsletter-form" id="newsletter-form" novalidate>
-                            <label class="sr-only" for="newsletter-email">Email</label>
-                            <input id="newsletter-email" type="email" name="email" placeholder="you@example.com" required>
-                            <button type="submit" class="button primary">Join the list</button>
-                            <p class="form-feedback" id="newsletter-feedback" role="status" aria-live="polite"></p>
-                        </form>
-                    </div>
-                    <div class="newsletter-media"></div>
-                </div>
-            </section>
-        </main>
-
-        <footer class="footer">
-            <div>
-                <strong>Nova Market</strong>
-                <p>Design-focused retail for the modern era.</p>
+            </header>
+            <div class="product-grid" id="product-grid" aria-live="polite"></div>
+            <div class="empty-state" id="empty-state" hidden>
+                <h3>No products found</h3>
+                <p>Try adjusting the search or choose another category to explore Ricktorious drops.</p>
+                <button type="button" class="button ghost" id="reset-filters">Reset filters</button>
             </div>
-            <div>
-                <h3>Support</h3>
-                <ul>
-                    <li><a href="#">Help center</a></li>
-                    <li><a href="#">Shipping &amp; returns</a></li>
-                    <li><a href="#">Order tracking</a></li>
-                    <li><a href="#">Accessibility</a></li>
-                </ul>
+        </div>
+    </section>
+
+    <section class="insights" id="insights">
+        <div class="shell insights-shell">
+            <header class="section-header">
+                <div>
+                    <h2>Visitor telemetry</h2>
+                    <p>Every interaction can be captured for recommendations and experimentation. These insights are sourced directly from the behavioural tracker.</p>
+                </div>
+            </header>
+            <div class="insight-grid" id="insight-panels">
+                <article class="insight-card">
+                    <h3>Total events</h3>
+                    <p class="metric" id="insight-events">0</p>
+                    <p class="muted">Events captured across cart, checkout, and content interactions for this session.</p>
+                </article>
+                <article class="insight-card">
+                    <h3>Popular blocks</h3>
+                    <ul class="tag-list" id="insight-blocks"></ul>
+                    <p class="muted">Block level engagement recorded by the AI personalisation engine.</p>
+                </article>
             </div>
-            <div>
-                <h3>Company</h3>
-                <ul>
-                    <li><a href="#">About</a></li>
-                    <li><a href="#">Careers</a></li>
-                    <li><a href="#">Press</a></li>
-                    <li><a href="#">Affiliate</a></li>
-                </ul>
+        </div>
+    </section>
+
+    <section class="checkout" id="checkout">
+        <div class="shell checkout-shell">
+            <header class="section-header">
+                <div>
+                    <h2>Checkout</h2>
+                    <p>Complete an order using the Ricktorious checkout API. Orders are persisted to the storage layer ready for fulfilment workflows.</p>
+                </div>
+            </header>
+            <div class="messages" id="checkout-messages" hidden></div>
+            <form id="checkout-form" class="checkout-form" novalidate>
+                <label>
+                    <span>Name</span>
+                    <input type="text" name="name" id="checkout-name" placeholder="Ada Lovelace" required>
+                </label>
+                <label>
+                    <span>Email</span>
+                    <input type="email" name="email" id="checkout-email" placeholder="ada@ricktorious.example" required>
+                </label>
+                <label class="full">
+                    <span>Delivery address</span>
+                    <textarea name="address" id="checkout-address" rows="4" placeholder="123 Commerce Avenue, Innovation District" required></textarea>
+                </label>
+                <button type="submit" class="button primary">Place order</button>
+            </form>
+        </div>
+    </section>
+</main>
+
+<div class="cart-overlay" id="cart-overlay" aria-hidden="true">
+    <div class="cart-panel" role="dialog" aria-modal="true" aria-labelledby="cart-title">
+        <header class="cart-header">
+            <h2 id="cart-title">Your cart</h2>
+            <button type="button" class="icon-button" id="cart-close" aria-label="Close cart">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </header>
+        <div class="cart-body" id="cart-body" aria-live="polite"></div>
+        <footer class="cart-footer">
+            <div class="cart-total">
+                <span>Total</span>
+                <strong id="cart-total">$0.00</strong>
             </div>
-            <div>
-                <h3>Follow</h3>
-                <ul class="social-links">
-                    <li><a href="#">Instagram</a></li>
-                    <li><a href="#">TikTok</a></li>
-                    <li><a href="#">Pinterest</a></li>
-                    <li><a href="#">YouTube</a></li>
-                </ul>
+            <div class="cart-actions">
+                <button type="button" class="button ghost" id="cart-clear">Clear cart</button>
+                <a class="button primary" href="#checkout" id="cart-checkout">Checkout</a>
             </div>
         </footer>
     </div>
+</div>
 
-    <aside class="cart-panel" id="cart-panel" aria-hidden="true">
-        <div class="cart-header">
-            <h2>Your bag</h2>
-            <button class="icon-button" id="cart-close" aria-label="Close cart">
-                <span class="icon icon-close"></span>
-            </button>
-        </div>
-        <div class="cart-body">
-            <ul class="cart-items" id="cart-items"></ul>
-            <div class="cart-empty" id="cart-empty">
-                <div class="empty-icon"></div>
-                <h3>Your bag is empty</h3>
-                <p>Add some statement pieces to see them here.</p>
-            </div>
-        </div>
-        <div class="cart-footer">
-            <div class="totals">
-                <div>
-                    <span>Subtotal</span>
-                    <strong id="cart-subtotal">$0.00</strong>
-                </div>
-                <div>
-                    <span>Shipping</span>
-                    <strong>Calculated at checkout</strong>
-                </div>
-            </div>
-            <button class="button primary" id="checkout-button">Secure checkout</button>
-            <p class="cart-note">Checkout is secured by end-to-end encryption and supports express payment providers.</p>
-        </div>
-    </aside>
-
-    <div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-hidden="true">
-        <div class="modal-backdrop" id="modal-backdrop"></div>
-        <div class="modal-dialog" role="document">
-            <button class="icon-button modal-close" id="modal-close" aria-label="Close product details">
-                <span class="icon icon-close"></span>
-            </button>
-            <div class="modal-gallery">
-                <img src="" alt="" id="modal-image">
-                <div class="thumbnail-row" id="modal-thumbnails"></div>
-            </div>
-            <div class="modal-body">
-                <h2 id="modal-title"></h2>
-                <p class="modal-price" id="modal-price"></p>
-                <p id="modal-description"></p>
-                <div class="modal-options">
-                    <div>
-                        <h3>Color</h3>
-                        <div class="chip-group" id="modal-colors"></div>
-                    </div>
-                    <div>
-                        <h3>Size</h3>
-                        <div class="chip-group" id="modal-sizes"></div>
-                    </div>
-                </div>
-                <button class="button primary" id="modal-add">Add to bag</button>
-            </div>
-        </div>
+<footer class="site-footer">
+    <div class="shell footer-shell">
+        <p>&copy; <?= date('Y'); ?> Ricktorious Limited. Built on the adaptive commerce kernel with extensible APIs for catalogue, cart, checkout, and fulfilment.</p>
     </div>
+</footer>
 
-    <script type="module" src="/web/assets/app.js?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>"></script>
+<div class="toast" id="app-toast" role="status" aria-live="polite" hidden></div>
+
+<script defer src="/web/assets/app.js?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow `/ricktorious.php/*` paths to resolve to the storefront router so API calls work from the new client.
- Extend the commerce API with summary helpers, cart update/remove/clear routes, and analytics event ingestion to support headless experiences.
- Replace the static demo with a Ricktorious Limited storefront that consumes the APIs, refreshes insights, and documents the new entry point.

## Testing
- php -l web/ricktorious.php
- php -l src/Ricktorious/Ecommerce/Extensions/CommerceExtension.php
- php -l web/storefront.php

------
https://chatgpt.com/codex/tasks/task_e_68e64a46d3248327bf2ca39fe3587e4a