### PR TITLE
Improve storefront deployment readiness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+node_modules
+vendor
+tests
+storage/orders/*
+storage/shipping/*
+storage/pos/*
+storage/users/*
+*.log
+Dockerfile
+composer.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:8.2-apache
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/web
+
+RUN sed -ri "s#/var/www/html#${APACHE_DOCUMENT_ROOT}#g" /etc/apache2/sites-available/000-default.conf \
+    && sed -ri "s#/var/www/html#${APACHE_DOCUMENT_ROOT}#g" /etc/apache2/sites-available/default-ssl.conf \
+    && a2enmod rewrite
+
+WORKDIR /var/www/html
+
+COPY web/ /var/www/html/web/
+COPY src/ /var/www/html/src/
+COPY storage/ /var/www/html/storage/
+COPY index.php /var/www/html/index.php
+COPY README.md /var/www/html/README.md
+COPY docs/ /var/www/html/docs/
+
+RUN chown -R www-data:www-data /var/www/html/storage
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -177,3 +177,17 @@ development server and open `http://localhost:8000/storefront.php` to try:
 
 Consult `docs/ricktorious-ecommerce.md` for an overview of the platform
 architecture and extension system.
+
+### Deploy in minutes
+
+- **Docker** – Build and run the bundled `Dockerfile` (or use
+  `docker compose up`) to start an Apache + PHP 8.2 container that serves the
+  storefront from the `web/` document root with persistent storage mounts.
+- **Shared hosting** – Upload the `web/`, `src/`, and `storage/` directories
+  and point your virtual host at `web/`. Ensure the storage directory remains
+  writable for order capture and telemetry.
+- **Health checks** – `/health.php` exposes a lightweight JSON heartbeat that
+  load balancers and uptime monitors can call.
+
+See `docs/deployment.md` for the full deployment checklist and environment
+notes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  ricktorious:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./storage:/var/www/html/storage
+    environment:
+      APACHE_DOCUMENT_ROOT: /var/www/html/web
+    healthcheck:
+      test: ["CMD", "php", "-r", "exit(file_exists('/var/www/html/web/health.php') ? 0 : 1);"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,60 @@
+# Deployment Guide
+
+The Ricktorious Limited storefront ships as a PHP application with no external
+service dependencies. This guide walks through three supported deployment
+options so you can get the experience online today.
+
+## 1. Run locally with PHP's built-in server
+
+```bash
+php -S 0.0.0.0:8000 -t web
+```
+
+Visit `http://localhost:8000/storefront.php` for the headless storefront or
+`http://localhost:8000/ricktorious.php` for the API surface.
+
+## 2. Containerised deployment
+
+1. Build the production image:
+   ```bash
+   docker build -t ricktorious-storefront .
+   ```
+2. Launch the containerised stack with persistent storage for orders and
+   telemetry:
+   ```bash
+   docker compose up -d
+   ```
+3. Browse to `http://localhost:8080/storefront.php`.
+
+The container uses the official `php:8.2-apache` image with the document root
+configured to `web/`. Storage directories are mounted as a volume so that order,
+shipping, POS, and user data survive restarts.
+
+## 3. Shared hosting / Apache
+
+1. Upload the `web/`, `src/`, and `storage/` directories along with `index.php`
+   to your hosting environment.
+2. Point the virtual host's document root at the `web/` directory.
+3. Ensure the `storage/` directory is writable by the web server user.
+
+### Health check endpoint
+
+The `/health.php` endpoint returns a JSON payload and can be wired into your
+load balancer or uptime monitoring service:
+
+```json
+{"status":"ok","timestamp":"2024-01-01T12:00:00+00:00"}
+```
+
+### Environment configuration
+
+Ricktorious stores catalogue and operational data under `storage/`. To start
+fresh in a new environment you can safely delete the nested directories:
+
+- `storage/orders/`
+- `storage/shipping/`
+- `storage/pos/`
+- `storage/users/`
+
+The catalogue lives at `storage/catalog/products.json` and can be updated with
+your own merchandise before deployment.

--- a/web/assets/app.js
+++ b/web/assets/app.js
@@ -1,4 +1,10 @@
-const API_BASE = '/ricktorious.php';
+const API_BASE = (() => {
+  const base = document.body?.dataset?.apiBase || 'ricktorious.php';
+  if (base.endsWith('/')) {
+    return base.replace(/\/+$/, '') || 'ricktorious.php';
+  }
+  return base;
+})();
 const endpoints = {
   products: `${API_BASE}/api/catalog/products`,
   cartSummary: `${API_BASE}/api/cart/summary`,

--- a/web/health.php
+++ b/web/health.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+echo json_encode([
+    'status' => 'ok',
+    'timestamp' => date(DATE_ATOM),
+]);

--- a/web/storefront.php
+++ b/web/storefront.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 session_start();
 
 $assetVersion = (string) (file_exists(__DIR__ . '/assets/styles.css') ? filemtime(__DIR__ . '/assets/styles.css') : time());
+
+$scriptName = (string) ($_SERVER['SCRIPT_NAME'] ?? '/storefront.php');
+$scriptDir = rtrim(str_replace('\\', '/', dirname($scriptName)), '/');
+if ($scriptDir === '' || $scriptDir === '.') {
+    $scriptDir = '';
+} elseif ($scriptDir === '/') {
+    $scriptDir = '';
+}
+
+$apiBase = ($scriptDir !== '' ? $scriptDir : '') . '/ricktorious.php';
+$apiBase = preg_replace('#//+#', '/', $apiBase) ?: '/ricktorious.php';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -11,12 +22,23 @@ $assetVersion = (string) (file_exists(__DIR__ . '/assets/styles.css') ? filemtim
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Ricktorious Limited — Adaptive Commerce Experience</title>
+    <meta name="description" content="Deploy the Ricktorious Limited adaptive commerce demo with personalised merchandising, realtime cart APIs, and integrated checkout workflows.">
+    <meta property="og:title" content="Ricktorious Limited — Adaptive Commerce Experience">
+    <meta property="og:description" content="Explore the adaptive commerce playground with catalogue APIs, behavioural insights, and a live checkout flow you can deploy today.">
+    <meta property="og:type" content="website">
+    <?php
+    $https = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+    $scheme = $https ? 'https' : 'http';
+    $host = (string) ($_SERVER['HTTP_HOST'] ?? 'example.com');
+    ?>
+    <meta property="og:url" content="<?= htmlspecialchars($scheme) ?>://<?= htmlspecialchars($host) ?><?= htmlspecialchars($scriptName) ?>">
+    <meta name="theme-color" content="#38bdf8">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/web/assets/styles.css?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>">
+    <link rel="stylesheet" href="assets/styles.css?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>">
 </head>
-<body>
+<body data-api-base="<?= htmlspecialchars($apiBase, ENT_QUOTES) ?>">
 <header class="site-header">
     <div class="shell header-shell">
         <div class="brand">Ricktorious Limited</div>
@@ -178,6 +200,6 @@ $assetVersion = (string) (file_exists(__DIR__ . '/assets/styles.css') ? filemtim
 
 <div class="toast" id="app-toast" role="status" aria-live="polite" hidden></div>
 
-<script defer src="/web/assets/app.js?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>"></script>
+<script defer src="assets/app.js?v=<?= htmlspecialchars($assetVersion, ENT_QUOTES) ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add containerisation assets, health endpoint, and a deployment guide for the Ricktorious storefront
- update the storefront markup and client code to work from any document root and add social metadata
- refresh the README with quick deployment guidance

## Testing
- php -l web/storefront.php
- php -l web/health.php

------
https://chatgpt.com/codex/tasks/task_e_68e65669b48c83278591d23144a0b9b3