### PR TITLE
Enable PDF crawling support

### DIFF
--- a/src/App/Crawler/HiddenCrawler.php
+++ b/src/App/Crawler/HiddenCrawler.php
@@ -5824,6 +5824,16 @@ final class HiddenCrawler
      */
     private function detectContentType(ScrapeResult $scraped, array $entry): string
     {
+        $contentMime = mb_strtolower($scraped->contentType());
+        if ($contentMime !== '' && str_contains($contentMime, 'pdf')) {
+            return 'document';
+        }
+
+        $urlLower = mb_strtolower($scraped->url());
+        if ($urlLower !== '' && str_ends_with($urlLower, '.pdf')) {
+            return 'document';
+        }
+
         $characterCount = (int) ($entry['character_count'] ?? $scraped->characterCount());
         $paragraphCount = (int) ($entry['paragraph_count'] ?? $scraped->paragraphCount());
         $publishedAt = trim((string) ($entry['published_at'] ?? ''));

--- a/src/App/News/NewsSearchService.php
+++ b/src/App/News/NewsSearchService.php
@@ -2316,6 +2316,10 @@ final class NewsSearchService
             $normalised = 'page';
         }
 
+        if ($normalised === 'document' || $normalised === 'pdf') {
+            return 'document';
+        }
+
         $characters = (int) ($entry['character_count'] ?? 0);
         $paragraphs = (int) ($entry['paragraph_count'] ?? 0);
         $summary = (string) ($entry['summary'] ?? $entry['preview'] ?? '');

--- a/src/App/Scraping/PdfDocumentParser.php
+++ b/src/App/Scraping/PdfDocumentParser.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scraping;
+
+use function array_slice;
+use function array_values;
+use function filter_var;
+use function implode;
+use function is_string;
+use function mb_check_encoding;
+use function mb_convert_encoding;
+use function mb_substr;
+use function parse_url;
+use function pathinfo;
+use function preg_match;
+use function preg_match_all;
+use function preg_replace;
+use function preg_split;
+use function rtrim;
+use function str_replace;
+use function trim;
+use function gzinflate;
+use function gzdecode;
+use function gzuncompress;
+
+use const FILTER_VALIDATE_URL;
+use const PATHINFO_FILENAME;
+use const PHP_URL_HOST;
+use const PHP_URL_PATH;
+
+final class PdfDocumentParser
+{
+    /**
+     * @param callable(string): string $normalise
+     *
+     * @return array{
+     *     title: string,
+     *     text: string,
+     *     paragraphs: array<int, string>,
+     *     links: array<int, string>,
+     *     meta: array<string, mixed>,
+     *     content_type: string
+     * }
+     */
+    public function parse(string $binary, string $url, callable $normalise): array
+    {
+        $text = trim($this->extractText($binary));
+        $paragraphs = $this->buildParagraphs($text, $normalise);
+        $title = $this->deriveTitle($binary, $url, $paragraphs, $normalise);
+        $links = $this->extractLinks($text);
+
+        $meta = [
+            'description' => '',
+            'image' => null,
+            'site_name' => '',
+            'published_at' => '',
+            'language' => '',
+            'canonical' => $url,
+            'content_type' => 'application/pdf',
+        ];
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if (is_string($host) && $host !== '') {
+            $meta['site_name'] = $host;
+        }
+
+        if ($paragraphs !== []) {
+            $meta['description'] = mb_substr($paragraphs[0], 0, 280);
+        }
+
+        $body = $paragraphs === []
+            ? ($text !== '' ? $this->invokeNormaliser($normalise, str_replace(["\r", "\n"], ' ', $text)) : '')
+            : implode("\n\n", $paragraphs);
+
+        return [
+            'title' => $title,
+            'text' => $body,
+            'paragraphs' => $paragraphs,
+            'links' => $links,
+            'meta' => $meta,
+            'content_type' => 'application/pdf',
+        ];
+    }
+
+    /**
+     * @param callable(string): string $normalise
+     *
+     * @return array<int, string>
+     */
+    private function buildParagraphs(string $text, callable $normalise): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        $normalisedBreaks = preg_replace('/\r\n?/u', "\n", $text);
+        if (!is_string($normalisedBreaks)) {
+            $normalisedBreaks = $text;
+        }
+
+        $chunks = preg_split('/\n{2,}/u', $normalisedBreaks);
+        if ($chunks === false) {
+            $chunks = [$normalisedBreaks];
+        }
+
+        $paragraphs = [];
+        foreach ($chunks as $chunk) {
+            if (!is_string($chunk)) {
+                continue;
+            }
+
+            $clean = $this->invokeNormaliser($normalise, str_replace("\n", ' ', $chunk));
+            if ($clean !== '') {
+                $paragraphs[] = $clean;
+            }
+        }
+
+        if ($paragraphs === [] && $normalisedBreaks !== '') {
+            $fallback = $this->invokeNormaliser($normalise, str_replace("\n", ' ', $normalisedBreaks));
+            if ($fallback !== '') {
+                $paragraphs[] = $fallback;
+            }
+        }
+
+        if ($paragraphs !== []) {
+            $paragraphs = array_values(array_slice(array_unique($paragraphs), 0, 40));
+        }
+
+        return $paragraphs;
+    }
+
+    /**
+     * @param array<int, string> $paragraphs
+     * @param callable(string): string $normalise
+     */
+    private function deriveTitle(string $binary, string $url, array $paragraphs, callable $normalise): string
+    {
+        if (preg_match('/\/Title\s*\(((?:\\\\.|[^()])*)\)/s', $binary, $match)) {
+            $candidate = $this->decodePdfString($match[1]);
+            $normalised = $this->invokeNormaliser($normalise, $candidate);
+            if ($normalised !== '') {
+                return $normalised;
+            }
+        }
+
+        if ($paragraphs !== []) {
+            foreach ($paragraphs as $paragraph) {
+                $candidate = trim($paragraph);
+                if ($candidate !== '') {
+                    return $candidate;
+                }
+            }
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        if (is_string($path) && $path !== '') {
+            $filename = pathinfo($path, PATHINFO_FILENAME);
+            if (is_string($filename) && $filename !== '') {
+                $pretty = $this->invokeNormaliser($normalise, str_replace('-', ' ', $filename));
+                if ($pretty !== '') {
+                    return $pretty;
+                }
+            }
+        }
+
+        return $this->invokeNormaliser($normalise, $url);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractLinks(string $text): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        if (!preg_match_all('/https?:\/\/[\w\-\.\/~%\?&=#:+,;@]+/iu', $text, $matches)) {
+            return [];
+        }
+
+        $links = [];
+        foreach ($matches[0] as $raw) {
+            if (!is_string($raw)) {
+                continue;
+            }
+
+            $candidate = rtrim($raw, '.,;)');
+            if ($candidate === '') {
+                continue;
+            }
+
+            if (filter_var($candidate, FILTER_VALIDATE_URL) === false) {
+                continue;
+            }
+
+            $links[] = $candidate;
+        }
+
+        return array_values(array_slice(array_unique($links), 0, 40));
+    }
+
+    private function extractText(string $binary): string
+    {
+        if ($binary === '') {
+            return '';
+        }
+
+        $fragments = [];
+        if (preg_match_all('/stream\r?\n(.*?)\r?\nendstream/s', $binary, $matches)) {
+            foreach ($matches[1] as $chunk) {
+                if (!is_string($chunk)) {
+                    continue;
+                }
+
+                $decoded = $this->decodeStream($chunk);
+                $text = $this->extractTextFromStream($decoded);
+                if ($text !== '') {
+                    $fragments[] = $text;
+                }
+            }
+        }
+
+        if ($fragments === []) {
+            $fallback = $this->extractTextFromStream($binary);
+            if ($fallback !== '') {
+                $fragments[] = $fallback;
+            }
+        }
+
+        $joined = trim(implode("\n", $fragments));
+        if ($joined === '') {
+            return '';
+        }
+
+        $sanitised = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/u', '', $joined);
+        return is_string($sanitised) ? trim($sanitised) : $joined;
+    }
+
+    private function decodeStream(string $chunk): string
+    {
+        $attempts = [
+            static fn(string $value) => @gzuncompress($value),
+            static fn(string $value) => @gzdecode($value),
+            static fn(string $value) => @gzinflate($value),
+        ];
+
+        foreach ($attempts as $attempt) {
+            $decoded = $attempt($chunk);
+            if (is_string($decoded) && $decoded !== '') {
+                return $decoded;
+            }
+        }
+
+        return $chunk;
+    }
+
+    private function extractTextFromStream(string $data): string
+    {
+        if ($data === '') {
+            return '';
+        }
+
+        $fragments = [];
+        if (preg_match_all('/\((?:\\\\.|[^()])*\)(?=\s*(?:Tj|TJ))/s', $data, $matches)) {
+            foreach ($matches[0] as $fragment) {
+                if (!is_string($fragment)) {
+                    continue;
+                }
+                $decoded = $this->decodePdfString(substr($fragment, 1, -1));
+                if ($decoded !== '') {
+                    $fragments[] = $decoded;
+                }
+            }
+        }
+
+        if (preg_match_all('/\[(.*?)\]\s*TJ/s', $data, $arrayMatches)) {
+            foreach ($arrayMatches[1] as $segment) {
+                if (!is_string($segment)) {
+                    continue;
+                }
+
+                if (!preg_match_all('/\((?:\\\\.|[^()])*\)/s', $segment, $parts)) {
+                    continue;
+                }
+
+                foreach ($parts[0] as $part) {
+                    if (!is_string($part)) {
+                        continue;
+                    }
+
+                    $decoded = $this->decodePdfString(substr($part, 1, -1));
+                    if ($decoded !== '') {
+                        $fragments[] = $decoded;
+                    }
+                }
+            }
+        }
+
+        if ($fragments === []) {
+            return '';
+        }
+
+        return trim(implode("\n", $fragments));
+    }
+
+    private function decodePdfString(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        $value = preg_replace_callback('/\\\d{1,3}/', static function (array $match): string {
+            $code = isset($match[0]) ? octdec(substr($match[0], 1)) : 0;
+            return chr($code);
+        }, $value);
+
+        if (!is_string($value)) {
+            $value = '';
+        }
+
+        $value = strtr($value, [
+            '\\n' => "\n",
+            '\\r' => "\r",
+            '\\t' => "\t",
+            '\\b' => "\b",
+            '\\f' => "\f",
+            '\\(' => '(',
+            '\\)' => ')',
+            '\\\\' => '\\',
+        ]);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $leading = substr($value, 0, 2);
+        if ($leading === "\xFE\xFF" || $leading === "\xFF\xFE") {
+            $converted = @mb_convert_encoding(substr($value, 2), 'UTF-8', $leading === "\xFE\xFF" ? 'UTF-16BE' : 'UTF-16LE');
+            if (is_string($converted) && $converted !== '') {
+                $value = $converted;
+            }
+        } elseif (!mb_check_encoding($value, 'UTF-8')) {
+            $converted = @mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
+            if (is_string($converted) && $converted !== '') {
+                $value = $converted;
+            }
+        }
+
+        return trim($value);
+    }
+
+    private function invokeNormaliser(callable $normalise, string $text): string
+    {
+        $value = $normalise($text);
+        return is_string($value) ? trim($value) : trim((string) $value);
+    }
+}

--- a/src/App/Scraping/ScrapeResult.php
+++ b/src/App/Scraping/ScrapeResult.php
@@ -31,12 +31,22 @@ final class ScrapeResult
      */
     private array $meta;
 
+    private string $contentType;
+
     /**
      * @param array<int, string> $paragraphs
      * @param array<int, string> $links
      * @param array<string, mixed> $meta
      */
-    public function __construct(string $url, string $title, string $text, array $paragraphs, array $links = [], array $meta = [])
+    public function __construct(
+        string $url,
+        string $title,
+        string $text,
+        array $paragraphs,
+        array $links = [],
+        array $meta = [],
+        string $contentType = 'text/html'
+    )
     {
         $this->url = $url;
         $this->title = $title;
@@ -44,6 +54,7 @@ final class ScrapeResult
         $this->paragraphs = $paragraphs;
         $this->links = array_values($links);
         $this->meta = $meta;
+        $this->contentType = $contentType !== '' ? $contentType : 'text/html';
     }
 
     public function url(): string
@@ -83,6 +94,11 @@ final class ScrapeResult
     public function meta(): array
     {
         return $this->meta;
+    }
+
+    public function contentType(): string
+    {
+        return $this->contentType;
     }
 
     public function thumbnail(): ?string
@@ -136,6 +152,7 @@ final class ScrapeResult
             'preview' => $this->preview(),
             'links' => array_slice($this->links, 0, 20),
             'meta' => $this->meta,
+            'content_type' => $this->contentType,
         ];
     }
 }

--- a/src/App/Scraping/WebScraper.php
+++ b/src/App/Scraping/WebScraper.php
@@ -33,12 +33,20 @@ use function stream_context_create;
 use function strpos;
 use function trim;
 use function substr;
+use function str_contains;
+use function str_ends_with;
+use function stripos;
+use const CURLINFO_CONTENT_TYPE;
+use const CURLINFO_EFFECTIVE_URL;
 use const FILTER_VALIDATE_URL;
+use const PHP_URL_PATH;
 use const PHP_URL_SCHEME;
 
 final class WebScraper implements ScraperInterface
 {
     private const USER_AGENT = 'AIresearchBot/1.0 (+https://github.com/)';
+
+    private ?PdfDocumentParser $pdfParser = null;
 
     /**
      * Download the page located at the given URL and return a cleaned ScrapeResult.
@@ -46,19 +54,40 @@ final class WebScraper implements ScraperInterface
     public function scrape(string $url): ScrapeResult
     {
         $normalisedUrl = $this->normaliseUrl($url);
-        $html = $this->download($normalisedUrl);
-        $document = $this->extractDocument($html, $normalisedUrl);
+        $downloaded = $this->download($normalisedUrl);
 
+        $effectiveUrl = $downloaded['url'] !== '' ? $downloaded['url'] : $normalisedUrl;
+
+        if ($this->isPdfResponse($downloaded['content_type'], $effectiveUrl)) {
+            $parsed = $this->pdfParser()->parse(
+                $downloaded['body'],
+                $effectiveUrl,
+                fn(string $value): string => $this->normaliseText($value)
+            );
+
+            return new ScrapeResult(
+                $effectiveUrl,
+                $parsed['title'],
+                $parsed['text'],
+                $parsed['paragraphs'],
+                $parsed['links'],
+                $parsed['meta'],
+                $parsed['content_type']
+            );
+        }
+
+        $document = $this->extractDocument($downloaded['body'], $effectiveUrl);
         $paragraphs = $document['paragraphs'];
         $text = trim(implode("\n\n", $paragraphs));
 
         return new ScrapeResult(
-            $normalisedUrl,
+            $effectiveUrl,
             $document['title'],
             $text,
             $paragraphs,
             $document['links'],
-            $document['meta']
+            $document['meta'],
+            $document['content_type']
         );
     }
 
@@ -76,7 +105,10 @@ final class WebScraper implements ScraperInterface
         return $trimmed;
     }
 
-    private function download(string $url): string
+    /**
+     * @return array{body: string, content_type: string, url: string}
+     */
+    private function download(string $url): array
     {
         if (function_exists('curl_init')) {
             $resource = curl_init($url);
@@ -91,7 +123,7 @@ final class WebScraper implements ScraperInterface
                 CURLOPT_CONNECTTIMEOUT => 10,
                 CURLOPT_TIMEOUT => 20,
                 CURLOPT_USERAGENT => self::USER_AGENT,
-                CURLOPT_HTTPHEADER => ['Accept: text/html,application/xhtml+xml']
+                CURLOPT_HTTPHEADER => ['Accept: text/html,application/xhtml+xml,application/pdf;q=0.9,*/*;q=0.8']
             ]);
 
             $body = curl_exec($resource);
@@ -101,8 +133,16 @@ final class WebScraper implements ScraperInterface
                 throw new RuntimeException($error !== '' ? $error : 'Unable to download URL.');
             }
 
+            $contentType = (string) curl_getinfo($resource, CURLINFO_CONTENT_TYPE);
+            $effectiveUrl = (string) curl_getinfo($resource, CURLINFO_EFFECTIVE_URL);
+
             curl_close($resource);
-            return $body;
+
+            return [
+                'body' => $body,
+                'content_type' => $contentType,
+                'url' => $effectiveUrl !== '' ? $effectiveUrl : $url,
+            ];
         }
 
         $context = stream_context_create([
@@ -110,7 +150,7 @@ final class WebScraper implements ScraperInterface
                 'method' => 'GET',
                 'header' => [
                     'User-Agent: ' . self::USER_AGENT,
-                    'Accept: text/html,application/xhtml+xml'
+                    'Accept: text/html,application/xhtml+xml,application/pdf;q=0.9,*/*;q=0.8'
                 ],
                 'timeout' => 20,
             ],
@@ -121,7 +161,30 @@ final class WebScraper implements ScraperInterface
             throw new RuntimeException('Unable to download URL.');
         }
 
-        return $body;
+        $contentType = '';
+        $effectiveUrl = $url;
+        if (isset($http_response_header) && is_array($http_response_header)) {
+            foreach ($http_response_header as $headerLine) {
+                if (!is_string($headerLine)) {
+                    continue;
+                }
+
+                if (stripos($headerLine, 'Content-Type:') === 0) {
+                    $contentType = trim(substr($headerLine, 13));
+                } elseif (stripos($headerLine, 'Location:') === 0) {
+                    $location = trim(substr($headerLine, 9));
+                    if ($location !== '') {
+                        $effectiveUrl = $location;
+                    }
+                }
+            }
+        }
+
+        return [
+            'body' => $body,
+            'content_type' => $contentType,
+            'url' => $effectiveUrl,
+        ];
     }
 
     /**
@@ -155,6 +218,7 @@ final class WebScraper implements ScraperInterface
                     'paragraphs' => $this->fallbackParagraphs($html),
                     'links' => [],
                     'meta' => $meta,
+                    'content_type' => 'text/html',
                 ];
             }
 
@@ -278,7 +342,35 @@ final class WebScraper implements ScraperInterface
             'paragraphs' => $paragraphs,
             'links' => $links,
             'meta' => $meta,
+            'content_type' => 'text/html',
         ];
+    }
+
+    private function isPdfResponse(string $contentType, string $url): bool
+    {
+        $contentType = trim($contentType);
+        if ($contentType !== '') {
+            $lower = mb_strtolower($contentType);
+            if (str_contains($lower, 'application/pdf')) {
+                return true;
+            }
+        }
+
+        $path = parse_url($url, PHP_URL_PATH);
+        if (is_string($path) && $path !== '') {
+            return str_ends_with(mb_strtolower($path), '.pdf');
+        }
+
+        return false;
+    }
+
+    private function pdfParser(): PdfDocumentParser
+    {
+        if ($this->pdfParser === null) {
+            $this->pdfParser = new PdfDocumentParser();
+        }
+
+        return $this->pdfParser;
     }
 
     private function normaliseText(string $text): string

--- a/tests/test_hidden_crawler.php
+++ b/tests/test_hidden_crawler.php
@@ -18,7 +18,7 @@ class StubScraper implements ScraperInterface
     {
         $text = $this->text;
 
-        return new ScrapeResult($url, 'Stub page', $text, [$text], []);
+        return new ScrapeResult($url, 'Stub page', $text, [$text], [], [], 'application/pdf');
     }
 }
 
@@ -69,7 +69,7 @@ if (!isset($first['topics']) || !is_array($first['topics']) || $first['topics'] 
 }
 
 $contentType = isset($first['content_type']) ? (string) $first['content_type'] : '';
-if (!in_array($contentType, ['article', 'page', 'non_article', 'error'], true)) {
+if (!in_array($contentType, ['article', 'page', 'non_article', 'error', 'document'], true)) {
     throw new RuntimeException('Crawler should classify entries by content type.');
 }
 

--- a/tests/test_pdf_parser.php
+++ b/tests/test_pdf_parser.php
@@ -1,0 +1,65 @@
+<?php
+require_once __DIR__ . '/../src/App/Scraping/PdfDocumentParser.php';
+
+use App\Scraping\PdfDocumentParser;
+
+$parser = new PdfDocumentParser();
+
+$pdf = <<<PDF
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj << /Length 98 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(Quarterly Results Overview) Tj
+0 -24 Td
+(See https://example.com/report for details.) Tj
+ET
+endstream
+endobj
+5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj << /Title (Sample Quarterly Report) >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+trailer << /Size 7 /Root 1 0 R /Info 6 0 R >>
+startxref
+0
+%%EOF
+PDF;
+
+$normalise = static function (string $text): string {
+    $collapsed = preg_replace('/\s+/u', ' ', $text);
+    if (!is_string($collapsed)) {
+        $collapsed = $text;
+    }
+
+    return trim($collapsed);
+};
+
+$document = $parser->parse($pdf, 'https://example.com/files/q1.pdf', $normalise);
+
+if ($document['content_type'] !== 'application/pdf') {
+    throw new RuntimeException('Expected parsed document to report application/pdf content type.');
+}
+
+if (stripos($document['title'], 'Quarterly') === false) {
+    throw new RuntimeException('PDF parser should extract the embedded title metadata.');
+}
+
+if ($document['paragraphs'] === [] || stripos($document['text'], 'Quarterly Results Overview') === false) {
+    throw new RuntimeException('PDF parser should expose text content extracted from the stream.');
+}
+
+if (!in_array('https://example.com/report', $document['links'], true)) {
+    throw new RuntimeException('PDF parser should detect hyperlinks embedded within the document text.');
+}


### PR DESCRIPTION
## Summary
- detect PDF responses in the web scraper and extract their text, metadata, and hyperlinks with a dedicated parser
- persist MIME type information on scraped sources and classify PDFs as documents in crawler and search views
- cover the new behaviour with parser and crawler tests

## Testing
- php tests/test_pdf_parser.php
- php tests/test_hidden_crawler.php
- php tests/test_research_service.php
- php tests/test_auto_crawler.php
- php tests/test_news_search_service.php

------
https://chatgpt.com/codex/tasks/task_e_68f8f78b6b9c8327887af724d29a190a