### PR TITLE
Add analyst training program page

### DIFF
--- a/assets/training.css
+++ b/assets/training.css
@@ -1,0 +1,402 @@
+:root {
+    --training-bg: radial-gradient(circle at top right, rgba(76, 143, 255, 0.18), transparent 45%),
+        radial-gradient(circle at bottom left, rgba(34, 197, 94, 0.16), transparent 40%),
+        #060914;
+    --training-surface: rgba(10, 17, 32, 0.88);
+    --training-border: rgba(110, 132, 200, 0.32);
+    --training-border-soft: rgba(110, 132, 200, 0.18);
+    --training-highlight: #5fffd2;
+    --training-accent: #8b5cf6;
+    --training-accent-soft: rgba(139, 92, 246, 0.22);
+}
+
+.training-site {
+    background: var(--training-bg);
+    color: var(--ai-color-text, #f5f7ff);
+}
+
+.training-main {
+    display: flex;
+    flex-direction: column;
+    gap: 5rem;
+    padding: 3.5rem 0 4.5rem;
+}
+
+.training-container {
+    width: min(1180px, calc(100% - 3rem));
+    margin: 0 auto;
+}
+
+.training-hero {
+    position: relative;
+}
+
+.training-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(76, 143, 255, 0.25), rgba(91, 33, 182, 0.2));
+    border-radius: 32px;
+    filter: blur(60px);
+    opacity: 0.6;
+}
+
+.training-hero > .training-container {
+    position: relative;
+    z-index: 1;
+    background: var(--training-surface);
+    border-radius: 32px;
+    padding: 3.5rem clamp(2rem, 4vw, 3rem);
+    border: 1px solid var(--training-border);
+    box-shadow: 0 40px 80px rgba(3, 7, 18, 0.55);
+    display: grid;
+    gap: 2.5rem;
+}
+
+.training-hero__content {
+    max-width: 640px;
+}
+
+.training-hero__content .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.2rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(95, 255, 210, 0.14);
+    color: var(--training-highlight);
+}
+
+.training-hero__content h1 {
+    font-size: clamp(2.2rem, 4vw, 3rem);
+    margin-bottom: 1rem;
+    letter-spacing: -0.03em;
+}
+
+.training-hero__content .lead {
+    color: rgba(224, 230, 255, 0.78);
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+}
+
+.training-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.training-hero__actions .button {
+    border-radius: 14px;
+    padding: 0.75rem 1.6rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+.button.button--primary {
+    background: linear-gradient(135deg, #60a5fa, #8b5cf6);
+    border: none;
+    color: #081021;
+    box-shadow: 0 14px 36px rgba(76, 143, 255, 0.35);
+}
+
+.button.button--primary:hover,
+.button.button--primary:focus-visible {
+    background: linear-gradient(135deg, #7dd3fc, #a855f7);
+    color: #050914;
+}
+
+.button.button--ghost {
+    background: transparent;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.button.button--ghost:hover,
+.button.button--ghost:focus-visible {
+    background: rgba(148, 163, 184, 0.2);
+    color: #f8fafc;
+}
+
+.training-hero__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+}
+
+.training-hero__metric {
+    background: rgba(14, 22, 43, 0.9);
+    border-radius: 20px;
+    padding: 1.5rem;
+    border: 1px solid var(--training-border-soft);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.training-hero__metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fef9ff;
+}
+
+.training-hero__metric-label {
+    font-weight: 500;
+    color: rgba(226, 232, 240, 0.75);
+}
+
+.training-hero__metric-detail {
+    font-size: 0.9rem;
+    color: rgba(148, 196, 255, 0.78);
+}
+
+.training-section__header {
+    max-width: 760px;
+    margin-bottom: 2.5rem;
+}
+
+.training-section__header .eyebrow {
+    display: inline-flex;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.8rem;
+    color: var(--training-highlight);
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid rgba(95, 255, 210, 0.35);
+    margin-bottom: 1rem;
+}
+
+.training-section__header h2 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.9rem, 3.4vw, 2.5rem);
+}
+
+.section-lead {
+    margin: 0;
+    color: rgba(219, 225, 255, 0.78);
+}
+
+.training-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.75rem;
+}
+
+.training-track {
+    background: rgba(9, 15, 29, 0.85);
+    border-radius: 22px;
+    padding: 2rem;
+    border: 1px solid var(--training-border-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    box-shadow: 0 18px 42px rgba(3, 7, 18, 0.45);
+}
+
+.training-track__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.training-track__header h3 {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.training-track__duration {
+    font-size: 0.9rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(139, 92, 246, 0.18);
+    color: rgba(209, 213, 255, 0.85);
+    border: 1px solid rgba(139, 92, 246, 0.4);
+}
+
+.training-track__list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: rgba(202, 213, 255, 0.85);
+}
+
+.training-track__list li {
+    line-height: 1.5;
+}
+
+.training-section--journey {
+    position: relative;
+}
+
+.training-journey {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.training-journey__phase {
+    background: rgba(13, 20, 38, 0.8);
+    border-radius: 20px;
+    padding: 1.75rem;
+    border: 1px solid var(--training-border-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.training-journey__phase h3 {
+    margin: 0;
+}
+
+.training-journey__phase ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: rgba(202, 213, 255, 0.82);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.training-journey__badge {
+    align-self: flex-start;
+    padding: 0.25rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(95, 255, 210, 0.45);
+    color: rgba(95, 255, 210, 0.9);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.training-section--workshops {
+    position: relative;
+}
+
+.training-table-wrapper {
+    overflow-x: auto;
+    background: rgba(9, 15, 29, 0.85);
+    border-radius: 22px;
+    border: 1px solid var(--training-border-soft);
+    box-shadow: 0 24px 48px rgba(3, 7, 18, 0.45);
+}
+
+.training-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 640px;
+}
+
+.training-table th,
+.training-table td {
+    padding: 1.1rem 1.5rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.training-table thead th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(148, 196, 255, 0.85);
+}
+
+.training-table tbody tr:last-child th,
+.training-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.training-section--resources .training-resources {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.training-resource {
+    background: rgba(10, 16, 30, 0.82);
+    border-radius: 20px;
+    padding: 1.75rem;
+    border: 1px solid var(--training-border-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.training-resource header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.training-resource__type {
+    margin: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(95, 255, 210, 0.85);
+}
+
+.training-resource h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.training-resource h3 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.training-resource h3 a:hover,
+.training-resource h3 a:focus-visible {
+    color: var(--training-highlight);
+    text-decoration: underline;
+}
+
+.training-resource__length {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(148, 196, 255, 0.8);
+}
+
+@media (max-width: 768px) {
+    .training-main {
+        gap: 4rem;
+        padding: 3rem 0;
+    }
+
+    .training-hero > .training-container {
+        padding: 2.75rem 1.75rem;
+    }
+
+    .training-hero__metrics {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .training-table {
+        min-width: 520px;
+    }
+}
+
+@media (max-width: 540px) {
+    .training-container {
+        width: calc(100% - 2.5rem);
+    }
+
+    .training-hero__actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .training-hero__metrics {
+        grid-template-columns: 1fr;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ $homeScriptVersion = file_exists(__DIR__ . '/assets/home.js') ? (string) filemti
 $homePath = PathResolver::url($assetBase, 'index.php');
 $searchPath = PathResolver::url($assetBase, 'search.php');
 $knowledgePath = PathResolver::url($assetBase, 'knowledge-graph.php');
+$trainingPath = PathResolver::url($assetBase, 'training.php');
 $marketsPath = PathResolver::url($assetBase, 'markets.php');
 $researchPath = PathResolver::url($assetBase, 'research.php');
 
@@ -134,6 +135,7 @@ if (!is_string($sampleQueriesJson)) {
             <nav class="home-nav" aria-label="Primary">
                 <a class="home-nav__link" href="<?= esc($searchPath) ?>">Search</a>
                 <a class="home-nav__link" href="<?= esc($knowledgePath) ?>">Knowledge graph</a>
+                <a class="home-nav__link" href="<?= esc($trainingPath) ?>">Training</a>
                 <a class="home-nav__link" href="<?= esc($marketsPath) ?>">Markets</a>
                 <a class="home-nav__link" href="<?= esc($researchPath) ?>">Research</a>
             </nav>

--- a/training.php
+++ b/training.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/src/App/bootstrap.php';
+
+use App\Web\PathResolver;
+use App\Web\SiteLayout;
+
+function esc(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+$paths = PathResolver::resolve();
+$assetBase = PathResolver::normalizeBase($paths['assetBase']);
+
+$themePath = PathResolver::url($assetBase, 'assets/theme.css');
+$stylesPath = PathResolver::url($assetBase, 'assets/styles.css');
+$trainingStylesPath = PathResolver::url($assetBase, 'assets/training.css');
+
+$themeVersion = file_exists(__DIR__ . '/assets/theme.css') ? (string) filemtime(__DIR__ . '/assets/theme.css') : (string) time();
+$stylesVersion = file_exists(__DIR__ . '/assets/styles.css') ? (string) filemtime(__DIR__ . '/assets/styles.css') : (string) time();
+$trainingStylesVersion = file_exists(__DIR__ . '/assets/training.css') ? (string) filemtime(__DIR__ . '/assets/training.css') : (string) time();
+
+$homePath = PathResolver::url($assetBase, 'index.php');
+$searchPath = PathResolver::url($assetBase, 'search.php');
+$graphPath = PathResolver::url($assetBase, 'knowledge-graph.php');
+$docsPath = PathResolver::url($assetBase, 'docs');
+
+$navigationLinks = [
+    'home' => ['label' => 'Home', 'href' => $homePath],
+    'search' => ['label' => 'Search', 'href' => $searchPath],
+    'graph' => ['label' => 'Knowledge graph', 'href' => $graphPath],
+    'training' => ['label' => 'Training', 'href' => PathResolver::url($assetBase, 'training.php')],
+];
+
+$footerLinks = [
+    ['label' => 'Home', 'href' => $homePath],
+    ['label' => 'Search', 'href' => $searchPath],
+    ['label' => 'Knowledge graph', 'href' => $graphPath],
+    ['label' => 'Research console', 'href' => PathResolver::url($assetBase, 'knowledge-graph-research.php')],
+    ['label' => 'Docs', 'href' => $docsPath],
+];
+
+$heroMetrics = [
+    [
+        'label' => 'Analysts onboarded',
+        'value' => '48',
+        'detail' => '+12 this quarter',
+    ],
+    [
+        'label' => 'Mean time to insight',
+        'value' => '32 min',
+        'detail' => 'Down 41% post-training',
+    ],
+    [
+        'label' => 'Briefings published',
+        'value' => '126',
+        'detail' => 'With graph citations',
+    ],
+];
+
+$learningTracks = [
+    [
+        'title' => 'Signal fundamentals',
+        'duration' => '90 minutes',
+        'description' => 'Master the unified search workflow, pivoting from raw crawls to curated entity views.',
+        'outcomes' => [
+            'Frame answerable questions using the crawler health dashboard.',
+            'Apply smart filters to surface trustworthy, high-signal sources.',
+            'Compose short research notes using cached highlights and snippets.',
+        ],
+    ],
+    [
+        'title' => 'Graph investigations',
+        'duration' => '2 hours',
+        'description' => 'Link entities, relations, and supporting passages to build defensible narratives.',
+        'outcomes' => [
+            'Interpret relation histograms to spot emerging competitors or partners.',
+            'Trace citation chains back to original documents for verification.',
+            'Export knowledge graph slices for stakeholder briefings.',
+        ],
+    ],
+    [
+        'title' => 'Automation playbooks',
+        'duration' => '75 minutes',
+        'description' => 'Automate ingestion and briefing prep with reusable command-line routines.',
+        'outcomes' => [
+            'Schedule ingestion refreshes with `research.php` and guardrails.',
+            'Batch score and archive entity facts for weekly reporting.',
+            'Trigger Autopilot briefs with custom prompt templates.',
+        ],
+    ],
+];
+
+$journeyPhases = [
+    [
+        'title' => 'Discover',
+        'summary' => 'Kick off with a live crawl preview and learn to scope research questions.',
+        'activities' => [
+            'Live walkthrough of crawler controls and ingestion metrics.',
+            'Group exercise drafting investigation prompts in the search workspace.',
+        ],
+    ],
+    [
+        'title' => 'Investigate',
+        'summary' => 'Blend search, graph, and entity insights to assemble a confident storyline.',
+        'activities' => [
+            'Hands-on lab mapping entity relations to spot blind spots.',
+            'Pair exercise reviewing confidence scores and source overlap.',
+        ],
+    ],
+    [
+        'title' => 'Deliver',
+        'summary' => 'Package insights for executives with reusable reporting patterns.',
+        'activities' => [
+            'Autopilot brief creation with inline edits and citations.',
+            'Export clinic covering CSV, PDF, and workspace share links.',
+        ],
+    ],
+];
+
+$workshops = [
+    [
+        'title' => 'Crawler operations clinic',
+        'cadence' => 'Tuesdays',
+        'time' => '15:00 UTC',
+        'duration' => '45 min',
+        'focus' => 'Tune ingestion rules, manage retries, and monitor pipeline health.',
+    ],
+    [
+        'title' => 'Graph storytelling lab',
+        'cadence' => 'Wednesdays',
+        'time' => '17:00 UTC',
+        'duration' => '60 min',
+        'focus' => 'Translate entity clusters into narrative arcs with supporting evidence.',
+    ],
+    [
+        'title' => 'Briefing automation sprint',
+        'cadence' => 'Thursdays',
+        'time' => '16:30 UTC',
+        'duration' => '40 min',
+        'focus' => 'Use templates and command-line tooling to ship publish-ready briefs.',
+    ],
+];
+
+$resourceLibrary = [
+    [
+        'title' => 'AIresearch operator handbook',
+        'type' => 'Guide',
+        'length' => '32 pages',
+        'href' => PathResolver::url($assetBase, 'docs/deployment.md'),
+        'description' => 'Platform architecture, deployment recipes, and access controls for admins.',
+    ],
+    [
+        'title' => 'Crawler quality checklist',
+        'type' => 'Checklist',
+        'length' => '12 steps',
+        'href' => PathResolver::url($assetBase, 'docs/data-quality-roadmap.md'),
+        'description' => 'Daily review cadence to keep ingestion clean, deduplicated, and reliable.',
+    ],
+    [
+        'title' => 'Workbench quickstart',
+        'type' => 'Playbook',
+        'length' => '15 minutes',
+        'href' => PathResolver::url($assetBase, 'docs/workbench.md'),
+        'description' => 'Spin up the analyst workbench, replay searches, and annotate findings.',
+    ],
+];
+
+$ctaLinks = [
+    [
+        'label' => 'Book a cohort',
+        'href' => 'mailto:training@airesearch.example',
+        'class' => 'button--primary',
+    ],
+    [
+        'label' => 'Launch workspace',
+        'href' => $searchPath,
+        'class' => 'button--ghost',
+    ],
+];
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Training &ndash; AIresearch</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="<?= esc($themePath . '?v=' . $themeVersion) ?>">
+    <link rel="stylesheet" href="<?= esc($stylesPath . '?v=' . $stylesVersion) ?>">
+    <link rel="stylesheet" href="<?= esc($trainingStylesPath . '?v=' . $trainingStylesVersion) ?>">
+</head>
+<body class="site training-site">
+<?php SiteLayout::renderHeader($navigationLinks, 'training', [
+    ['label' => 'Launch search', 'href' => $searchPath, 'class' => 'button--ghost'],
+]); ?>
+<main class="site-main training-main">
+    <section class="training-hero">
+        <div class="training-container">
+            <div class="training-hero__content">
+                <p class="eyebrow">Analyst enablement</p>
+                <h1>Level up every investigation with guided practice</h1>
+                <p class="lead">From first crawl to executive-ready briefings, the AIresearch training programme equips your team with a repeatable workflow, live coaching, and ready-to-share templates.</p>
+                <div class="training-hero__actions">
+                    <?php foreach ($ctaLinks as $cta): ?>
+                        <?php if (!isset($cta['label'], $cta['href'])) { continue; } ?>
+                        <?php $ctaClassSuffix = isset($cta['class']) && is_string($cta['class']) ? trim($cta['class']) : ''; ?>
+                        <?php $ctaClasses = trim('button ' . $ctaClassSuffix); ?>
+                        <a class="<?= esc($ctaClasses) ?>" href="<?= esc($cta['href']) ?>"><?= esc($cta['label']) ?></a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+            <?php if ($heroMetrics !== []): ?>
+                <div class="training-hero__metrics" aria-label="Training impact metrics">
+                    <?php foreach ($heroMetrics as $metric): ?>
+                        <?php $metricLabel = (string) ($metric['label'] ?? ''); ?>
+                        <?php $metricValue = (string) ($metric['value'] ?? ''); ?>
+                        <?php $metricDetail = (string) ($metric['detail'] ?? ''); ?>
+                        <?php if ($metricLabel === '' || $metricValue === '') { continue; } ?>
+                        <article class="training-hero__metric">
+                            <span class="training-hero__metric-value"><?= esc($metricValue) ?></span>
+                            <span class="training-hero__metric-label"><?= esc($metricLabel) ?></span>
+                            <?php if ($metricDetail !== ''): ?>
+                                <span class="training-hero__metric-detail"><?= esc($metricDetail) ?></span>
+                            <?php endif; ?>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section class="training-section">
+        <div class="training-container">
+            <header class="training-section__header">
+                <p class="eyebrow">Programme tracks</p>
+                <h2>Focused learning paths for every role</h2>
+                <p class="section-lead">Blend self-paced modules with live workshops. Each track includes ready-to-use exercises so analysts can apply new skills to their active investigations.</p>
+            </header>
+            <div class="training-grid">
+                <?php foreach ($learningTracks as $track): ?>
+                    <?php $title = (string) ($track['title'] ?? ''); ?>
+                    <?php $description = (string) ($track['description'] ?? ''); ?>
+                    <?php if ($title === '' || $description === '') { continue; } ?>
+                    <article class="training-track">
+                        <header class="training-track__header">
+                            <h3><?= esc($title) ?></h3>
+                            <?php $duration = (string) ($track['duration'] ?? ''); ?>
+                            <?php if ($duration !== ''): ?>
+                                <span class="training-track__duration"><?= esc($duration) ?></span>
+                            <?php endif; ?>
+                        </header>
+                        <p><?= esc($description) ?></p>
+                        <?php if (isset($track['outcomes']) && is_array($track['outcomes']) && $track['outcomes'] !== []): ?>
+                            <ul class="training-track__list">
+                                <?php foreach ($track['outcomes'] as $outcome): ?>
+                                    <?php if (!is_string($outcome)) { continue; } ?>
+                                    <?php $trimmed = trim($outcome); ?>
+                                    <?php if ($trimmed === '') { continue; } ?>
+                                    <li><?= esc($trimmed) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    <section class="training-section training-section--journey">
+        <div class="training-container">
+            <header class="training-section__header">
+                <p class="eyebrow">Experience arc</p>
+                <h2>Guided journey from discovery to delivery</h2>
+                <p class="section-lead">Every cohort rotates through themed labs that mirror the analyst workflow. Facilitators stay with the same group to provide context-aware coaching.</p>
+            </header>
+            <div class="training-journey">
+                <?php foreach ($journeyPhases as $index => $phase): ?>
+                    <?php $phaseTitle = (string) ($phase['title'] ?? ''); ?>
+                    <?php if ($phaseTitle === '') { continue; } ?>
+                    <article class="training-journey__phase">
+                        <div class="training-journey__badge" aria-hidden="true">Phase <?= esc((string) ($index + 1)) ?></div>
+                        <h3><?= esc($phaseTitle) ?></h3>
+                        <?php $summary = (string) ($phase['summary'] ?? ''); ?>
+                        <?php if ($summary !== ''): ?>
+                            <p><?= esc($summary) ?></p>
+                        <?php endif; ?>
+                        <?php if (isset($phase['activities']) && is_array($phase['activities']) && $phase['activities'] !== []): ?>
+                            <ul>
+                                <?php foreach ($phase['activities'] as $activity): ?>
+                                    <?php if (!is_string($activity)) { continue; } ?>
+                                    <?php $activityText = trim($activity); ?>
+                                    <?php if ($activityText === '') { continue; } ?>
+                                    <li><?= esc($activityText) ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    <section class="training-section training-section--workshops">
+        <div class="training-container">
+            <header class="training-section__header">
+                <p class="eyebrow">Live sessions</p>
+                <h2>Weekly workshops to reinforce best practice</h2>
+                <p class="section-lead">Join structured labs that pair short demos with guided implementation time. Sessions repeat monthly so new hires can plug in without waiting for the next cohort.</p>
+            </header>
+            <div class="training-table-wrapper">
+                <table class="training-table">
+                    <caption class="visually-hidden">Training workshops schedule</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Workshop</th>
+                            <th scope="col">Cadence</th>
+                            <th scope="col">Time</th>
+                            <th scope="col">Duration</th>
+                            <th scope="col">Focus</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($workshops as $workshop): ?>
+                            <?php $title = (string) ($workshop['title'] ?? ''); ?>
+                            <?php $focus = (string) ($workshop['focus'] ?? ''); ?>
+                            <?php if ($title === '' || $focus === '') { continue; } ?>
+                            <tr>
+                                <th scope="row"><?= esc($title) ?></th>
+                                <td><?= esc((string) ($workshop['cadence'] ?? '')) ?></td>
+                                <td><?= esc((string) ($workshop['time'] ?? '')) ?></td>
+                                <td><?= esc((string) ($workshop['duration'] ?? '')) ?></td>
+                                <td><?= esc($focus) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <section class="training-section training-section--resources">
+        <div class="training-container">
+            <header class="training-section__header">
+                <p class="eyebrow">Resource library</p>
+                <h2>Keep momentum between sessions</h2>
+                <p class="section-lead">Reference guides, checklists, and playbooks stay updated with every product release. Share them in your team workspace or link directly from onboarding docs.</p>
+            </header>
+            <div class="training-resources">
+                <?php foreach ($resourceLibrary as $resource): ?>
+                    <?php $resourceTitle = (string) ($resource['title'] ?? ''); ?>
+                    <?php $href = (string) ($resource['href'] ?? ''); ?>
+                    <?php if ($resourceTitle === '' || $href === '') { continue; } ?>
+                    <article class="training-resource">
+                        <header>
+                            <p class="training-resource__type"><?= esc((string) ($resource['type'] ?? '')) ?></p>
+                            <h3><a href="<?= esc($href) ?>"><?= esc($resourceTitle) ?></a></h3>
+                        </header>
+                        <p><?= esc((string) ($resource['description'] ?? '')) ?></p>
+                        <?php $length = (string) ($resource['length'] ?? ''); ?>
+                        <?php if ($length !== ''): ?>
+                            <p class="training-resource__length"><?= esc($length) ?></p>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+</main>
+<?php SiteLayout::renderFooter($footerLinks, 'Fast briefings start with confident analysts.'); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated training.php workspace that highlights programme tracks, journey phases, workshops, and resources
- style the training experience with a new assets/training.css theme and CTA treatments
- link to the new training page from the home navigation for quick access

## Testing
- php -l index.php
- php -l training.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911884c3cb08327bfee8f84c7e9f4bb)